### PR TITLE
fix: arm64 Docker ビルドの QEMU エラーを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
+FROM --platform=linux/amd64 docker.io/denoland/deno:2.6.10 AS build
+
+WORKDIR /app
+
+COPY . .
+RUN deno install
+RUN deno task build
+
 FROM docker.io/denoland/deno:2.6.10
 
 ARG GIT_REVISION
@@ -7,7 +15,7 @@ WORKDIR /app
 
 COPY . .
 RUN deno install
-RUN deno task build
+COPY --from=build /app/_fresh ./_fresh
 RUN deno cache _fresh/server.js
 
 EXPOSE 8000


### PR DESCRIPTION
## Summary
- QEMU エミュレーションでの arm64 Vite ビルドで `EISDIR: illegal operation on a directory, open '/'` エラーが発生する問題を修正
- Dockerfile をマルチステージ化し、ビルドステージを `--platform=linux/amd64` に固定
- ビルド成果物（JS/CSS）はアーキテクチャ非依存のため、amd64 でビルドした `_fresh/` をそのまま arm64 イメージにコピー

## Test plan
- [ ] GitHub Actions で v2.0.0 相当のリリースビルドが成功すること
- [ ] arm64 イメージが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)