### PR TITLE
docs: CLAUDE.md を .claude/rules/ 配下に分割 + 運用知見を追記

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,16 +16,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## ルール構成の早見
 
-| ファイル | 内容 |
-|---|---|
-| `rules/project.md` | プロジェクト概要 / テックスタック / コマンド |
-| `rules/architecture.md` | Fresh Island / API プロキシ / API フック / スタイリング / 国際化 |
-| `rules/watch.md` | ライブ視聴 UI の設計と既知の制限 |
-| `rules/env.md` | 環境変数 (`MIRAKC_API_URL`, `VITE_ALLOWED_HOSTS`) |
-| `rules/devcontainer.md` | 開発環境 (devcontainer) のセットアップと注意事項 |
-| `rules/docker.md` | 本番 Docker のステージ構成と `$BUILDPLATFORM` 運用 |
-| `rules/deno.md` | Deno 設定の注意点 |
-| `rules/pr-review.md` | Pull Request / Issue の Claude レビュー手順 |
-| `rules/tips.md` | 実装・運用の知見 (devcontainer crash / Preact 規約 / stream 管理 / mirakc 連携 等) |
+| ファイル                | 内容                                                                               |
+| ----------------------- | ---------------------------------------------------------------------------------- |
+| `rules/project.md`      | プロジェクト概要 / テックスタック / コマンド                                       |
+| `rules/architecture.md` | Fresh Island / API プロキシ / API フック / スタイリング / 国際化                   |
+| `rules/watch.md`        | ライブ視聴 UI の設計と既知の制限                                                   |
+| `rules/env.md`          | 環境変数 (`MIRAKC_API_URL`, `VITE_ALLOWED_HOSTS`)                                  |
+| `rules/devcontainer.md` | 開発環境 (devcontainer) のセットアップと注意事項                                   |
+| `rules/docker.md`       | 本番 Docker のステージ構成と `$BUILDPLATFORM` 運用                                 |
+| `rules/deno.md`         | Deno 設定の注意点                                                                  |
+| `rules/pr-review.md`    | Pull Request / Issue の Claude レビュー手順                                        |
+| `rules/tips.md`         | 実装・運用の知見 (devcontainer crash / Preact 規約 / stream 管理 / mirakc 連携 等) |
 
 新しい知見を追加するときは対応する rules ファイルに追記する。どのファイルに該当するか迷うものは `rules/tips.md` に書く。
+
+内容が短いファイル (`env.md`, `deno.md` 等) も**統合せずに独立維持**する方針。将来その領域の知見が追加されたときにファイル分割をやり直さずに済むため。

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,105 +2,30 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## プロジェクト概要
+本プロジェクトの開発ルール / 実装知見は `.claude/rules/` 配下にトピック別に分割している。Claude Code は `@path` 記法の import を解決するため、以下のファイルが CLAUDE.md と一緒に読み込まれる。
 
-[mirakc](https://github.com/mirakc/mirakc) 向けの Web UI。番組表閲覧、録画管理、番組検索機能を提供する。
+@./rules/project.md
+@./rules/architecture.md
+@./rules/watch.md
+@./rules/env.md
+@./rules/devcontainer.md
+@./rules/docker.md
+@./rules/deno.md
+@./rules/pr-review.md
+@./rules/tips.md
 
-## テックスタック
+## ルール構成の早見
 
-- **フレームワーク**: Fresh 2.x（Deno ベース）
-- **UI**: Preact + @preact/signals
-- **ビルド**: Vite（`vite.config.ts` に CSS 強制注入カスタムプラグインあり）
-- **ランタイム**: Deno 2.x
-- **API クライアント**: openapi-fetch + openapi-typescript による型安全な API 呼び出し
-- **国際化**: i18next（日本語のみ）
-- **スタイリング**: CSS モジュール + グローバル CSS 変数（ライト/ダークモード対応）
+| ファイル | 内容 |
+|---|---|
+| `rules/project.md` | プロジェクト概要 / テックスタック / コマンド |
+| `rules/architecture.md` | Fresh Island / API プロキシ / API フック / スタイリング / 国際化 |
+| `rules/watch.md` | ライブ視聴 UI の設計と既知の制限 |
+| `rules/env.md` | 環境変数 (`MIRAKC_API_URL`, `VITE_ALLOWED_HOSTS`) |
+| `rules/devcontainer.md` | 開発環境 (devcontainer) のセットアップと注意事項 |
+| `rules/docker.md` | 本番 Docker のステージ構成と `$BUILDPLATFORM` 運用 |
+| `rules/deno.md` | Deno 設定の注意点 |
+| `rules/pr-review.md` | Pull Request / Issue の Claude レビュー手順 |
+| `rules/tips.md` | 実装・運用の知見 (devcontainer crash / Preact 規約 / stream 管理 / mirakc 連携 等) |
 
-## コマンド
-
-```bash
-deno task dev        # 開発サーバー起動（vite、ポート 5173）
-deno task build      # 本番ビルド（_fresh/ に出力）
-deno task start      # ビルド済みアプリを起動（deno serve）
-deno task check      # fmt チェック + lint + 型チェック（CI 相当）
-deno task fix        # deno lint --fix + deno fmt で自動修正
-deno task generate   # OpenAPI スキーマから hooks/api/schema.d.ts を再生成
-```
-
-lint プラグインとして `@aireone/deno-lint-curly` を使用しており、1 行の `if` でも波括弧が必須。`deno task check` が失敗したら `deno task fix` で多くは解消する。
-
-## アーキテクチャ
-
-### Fresh の Island Architecture
-
-- `routes/` — ファイルシステムベースルーティング。サーバーサイドレンダリング。
-- `islands/` — クライアント側でハイドレーションされるインタラクティブコンポーネント。
-- `components/` — Atomic Design 構成（atoms → molecules → organisms → templates）。
-
-### API プロキシ
-
-`routes/api/mirakc/[...path].ts` が mirakc バックエンドへのプロキシとして機能する。環境変数 `MIRAKC_API_URL` でバックエンド URL を指定する。CORS 回避のためサーバーサイドプロキシパターンを採用。
-
-### API フック
-
-`hooks/api/` に `useGet`, `usePost`, `useDelete` を提供。`openapi-fetch` と生成された `schema.d.ts` により完全な型安全性を実現。状態遷移: `before` → `pending` → `fulfilled/rejected`。
-
-### スタイリング
-
-- `assets/styles/palette.css` — CSS 変数によるカラートークン。`light-dark()` 関数でテーマ切り替え。ジャンル別カラー（16色）定義。
-- コンポーネントスコープは `.module.css` で管理。
-- `vite.config.ts` の `force-inject-all-css` プラグインにより、ビルド時に全 CSS を島コンポーネントに強制注入（モジュール CSS の読み込み漏れ対策）。
-
-### 国際化
-
-`locales/ja-JP/` にスコープ別翻訳ファイル（common, program, recording, search, watch）を配置。
-
-### ライブ視聴とトランスコード
-
-- **ページ**: `/watch/[serviceId]`。`islands/Watch.tsx` がプレイヤー島、`components/organisms/Watch/` に UI 部品。
-- **トランスコード API**: `routes/api/transcode/services/[id].ts`。パイプラインは mirakc のサービスストリーム → `tsreadex`（字幕・音声整形）→ `ffmpeg`（H.264 / AAC に再エンコード）→ MPEG-TS をチャンク応答。
-- **再生**: `mpegts.js`（MSE ベース）で `<video>` にアタッチ、`aribb24.js` で ARIB 字幕を canvas オーバーレイ。
-- **HW エンコーダー自動検出**: 起動時に `h264_v4l2m2m` と `libx264` を順に**実エンコードテスト (probe)** で検証し、成功した方をキャッシュ。WSL2 等でカーネルモジュール不在の場合は `libx264` にフォールバック。両方失敗時は `503 No usable H.264 encoder found` を返す。
-- **デバッグログ**: tsreadex / ffmpeg / encoder-probe の stderr は `[tsreadex]` / `[ffmpeg]` / `[encoder-probe ${name}]` のプレフィックス付きで `console.error` に出力する (`docker logs mirakc-ui-app-1` で確認可)。
-- **URL 状態管理**: `serviceId` はパスパラメータ、`audioTrack` / `quality` / `caption` はクエリパラメータ。
-
-## 環境変数
-
-- `MIRAKC_API_URL` — mirakc API のベース URL（例: `http://mirakc:40772/api`）。`.env`（ホスト実行時）または `.devcontainer/.env`（devcontainer）に設定。
-- `VITE_ALLOWED_HOSTS` — Vite dev サーバの `server.allowedHosts` を env から設定する。カンマ区切りのホスト名（例: `raspberrypi.local,.local`）、または `true` / `all` で全許可。未設定なら Vite デフォルト動作。Raspberry Pi 等の非 localhost 経由で開発サーバにアクセスする場合に使用する。
-
-## 開発環境（devcontainer）
-
-`.devcontainer/` に VS Code / `devcontainer` CLI 用の構成を配置。2 サービス構成:
-
-- `workspace` — Debian bookworm ベース。VS Code / CLI の接続先。
-- `app` — プロジェクトルートの `Dockerfile` からビルド。`deno task dev --host 0.0.0.0` を起動しポート 5173 を公開。
-
-### セットアップ
-
-1. `cp .devcontainer/.env.example .devcontainer/.env` し、`MIRAKC_API_URL` を設定。
-2. 起動:
-   - VS Code: "Reopen in Container"
-   - CLI: `devcontainer up --workspace-folder .`
-3. `http://localhost:5173/` で UI、`http://localhost:5173/api/mirakc/version` でバックエンド疎通を確認。
-
-### 注意事項
-
-- **Dockerfile を変更した後**: 古い `mirakc-ui-app` イメージがキャッシュされると tsreadex / ffmpeg が入らない状態になる。`devcontainer up --remove-existing-container --build-no-cache` で強制再ビルドする。
-- **DooD**: `docker-outside-of-docker` feature を使用し、ホストの `/var/run/docker.sock` をバインド。`postStartCommand.sh` でソケット権限を調整している。
-
-## Docker（本番）
-
-マルチステージビルド。linux/amd64, linux/arm64 対応。GitHub Actions で GHCR に自動パブリッシュ。
-
-ステージ構成:
-
-1. `mirakc-ui-build` — Deno イメージで `deno task build` を実行し `_fresh/` を生成。
-2. `tsreadex-build` — Debian bookworm-slim。[tsreadex](https://github.com/xtne6f/tsreadex)（`master-240517`）をソースビルドしてバイナリ化。
-3. 最終ステージ — Deno イメージに `ffmpeg` を apt で追加し、`tsreadex` バイナリをコピー。実行時に `routes/api/transcode/services/[id].ts` から spawn される。
-
-## Deno 設定の注意点
-
-- `nodeModulesDir: "manual"` — npm 互換性モード
-- `jsx: "precompile"` / `jsxImportSource: "preact"`
-- `hooks/api/schema.d.ts` と `_fresh/` は lint/fmt の除外対象
+新しい知見を追加するときは対応する rules ファイルに追記する。どのファイルに該当するか迷うものは `rules/tips.md` に書く。

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,25 @@
+# アーキテクチャ
+
+## Fresh の Island Architecture
+
+- `routes/` — ファイルシステムベースルーティング。サーバーサイドレンダリング。
+- `islands/` — クライアント側でハイドレーションされるインタラクティブコンポーネント。
+- `components/` — Atomic Design 構成（atoms → molecules → organisms → templates）。
+
+## API プロキシ
+
+`routes/api/mirakc/[...path].ts` が mirakc バックエンドへのプロキシとして機能する。環境変数 `MIRAKC_API_URL` でバックエンド URL を指定する。CORS 回避のためサーバーサイドプロキシパターンを採用。
+
+## API フック
+
+`hooks/api/` に `useGet`, `usePost`, `useDelete` を提供。`openapi-fetch` と生成された `schema.d.ts` により完全な型安全性を実現。状態遷移: `before` → `pending` → `fulfilled/rejected`。戻り値は `{ state, data, error, loading, mutate }`。
+
+## スタイリング
+
+- `assets/styles/palette.css` — CSS 変数によるカラートークン。`light-dark()` 関数でテーマ切り替え。ジャンル別カラー（16色）定義。
+- コンポーネントスコープは `.module.css` で管理。
+- `vite.config.ts` の `force-inject-all-css` プラグインにより、ビルド時に全 CSS を島コンポーネントに強制注入（モジュール CSS の読み込み漏れ対策）。
+
+## 国際化
+
+`locales/ja-JP/` にスコープ別翻訳ファイル（common, program, recording, search, watch）を配置。

--- a/.claude/rules/deno.md
+++ b/.claude/rules/deno.md
@@ -1,0 +1,6 @@
+# Deno 設定の注意点
+
+- `nodeModulesDir: "manual"` — npm 互換性モード
+- `jsx: "precompile"` / `jsxImportSource: "preact"`
+- `hooks/api/schema.d.ts` と `_fresh/` は lint/fmt の除外対象
+- Deno のバージョンは Dockerfile の `FROM docker.io/denoland/deno:<version>` と `.devcontainer/onCreateCommand.sh` の `v<version>` 指定を揃える。上げる際は両方同時に更新する

--- a/.claude/rules/devcontainer.md
+++ b/.claude/rules/devcontainer.md
@@ -1,0 +1,20 @@
+# 開発環境 (devcontainer)
+
+`.devcontainer/` に VS Code / `devcontainer` CLI 用の構成を配置。2 サービス構成:
+
+- `workspace` — Debian bookworm ベース。VS Code / CLI の接続先。
+- `app` — プロジェクトルートの `Dockerfile` からビルド。`deno task dev --host 0.0.0.0` を起動しポート 5173 を公開。
+
+## セットアップ
+
+1. `cp .devcontainer/.env.example .devcontainer/.env` し、`MIRAKC_API_URL` を設定。
+2. 起動:
+   - VS Code: "Reopen in Container"
+   - CLI: `devcontainer up --workspace-folder .`
+3. `http://localhost:5173/` で UI、`http://localhost:5173/api/mirakc/version` でバックエンド疎通を確認。
+
+## 注意事項
+
+- **Dockerfile を変更した後**: 古い `mirakc-ui-app` イメージがキャッシュされると新しい依存や変更が反映されない。`devcontainer up --remove-existing-container --build-no-cache` で強制再ビルドする。
+- **DooD**: `docker-outside-of-docker` feature を使用し、ホストの `/var/run/docker.sock` をバインド。`postStartCommand.sh` でソケット権限を調整している。
+- **`deno task check/fix` で app コンテナが crash する罠あり** — 対処は [tips.md](./tips.md) 参照。

--- a/.claude/rules/docker.md
+++ b/.claude/rules/docker.md
@@ -1,0 +1,22 @@
+# Docker (本番)
+
+マルチステージビルド。linux/amd64, linux/arm64 対応。GitHub Actions で GHCR に自動パブリッシュ。
+
+## ステージ構成
+
+1. `mirakc-ui-build` — Deno イメージで `deno task build` を実行し `_fresh/` を生成。
+2. 最終ステージ — Deno イメージに `_fresh/` をコピーして `deno serve` で起動。
+
+## `$BUILDPLATFORM` の使い分け
+
+build ステージは `--platform=$BUILDPLATFORM` にしている。Buildx が実行ホストのネイティブ platform を割り当てるため、
+
+- CI (amd64 runner): `$BUILDPLATFORM` は `linux/amd64` に解決される → QEMU を介さずにビルド
+- Raspberry Pi (arm64 ホスト): `$BUILDPLATFORM` は `linux/arm64` に解決される → ネイティブビルド
+
+が両立する。過去に `--platform=linux/amd64` 固定にしていた時期があるが、QEMU エミュレーションで Vite ビルドが `EISDIR` になる問題の回避が目的だった ([fe770ad](https://github.com/ansanloms/mirakc-ui/commit/fe770ad), [c5ee238](https://github.com/ansanloms/mirakc-ui/commit/c5ee238))。現在は `$BUILDPLATFORM` 化で両対応 ([#14](https://github.com/ansanloms/mirakc-ui/pull/14))。
+
+## トランスコード層採用時の差分
+
+- [#11 A 方式](https://github.com/ansanloms/mirakc-ui/issues/11) を採用する場合はこの最終ステージに `ffmpeg` / `tsreadex` を追加する
+- [#16 B' 方式](https://github.com/ansanloms/mirakc-ui/issues/16) を採用する場合は Dockerfile は触らず、mirakc 側の `post-filters` 設定で扱う

--- a/.claude/rules/docker.md
+++ b/.claude/rules/docker.md
@@ -5,18 +5,18 @@
 ## ステージ構成
 
 1. `mirakc-ui-build` — Deno イメージで `deno task build` を実行し `_fresh/` を生成。
-2. 最終ステージ — Deno イメージに `_fresh/` をコピーして `deno serve` で起動。
+2. `tsreadex-build` — Debian bookworm-slim。[tsreadex](https://github.com/xtne6f/tsreadex)（`master-240517`）をソースビルドしてバイナリ化。
+3. 最終ステージ — Deno イメージに `ffmpeg` を apt で追加し、`tsreadex` バイナリをコピー。実行時に `routes/api/transcode/services/[id].ts` から spawn される。
 
 ## `$BUILDPLATFORM` の使い分け
 
-build ステージは `--platform=$BUILDPLATFORM` にしている。Buildx が実行ホストのネイティブ platform を割り当てるため、
+`mirakc-ui-build` ステージは `--platform=$BUILDPLATFORM` にしている。Buildx が実行ホストのネイティブ platform を割り当てるため、
 
 - CI (amd64 runner): `$BUILDPLATFORM` は `linux/amd64` に解決される → QEMU を介さずにビルド
 - Raspberry Pi (arm64 ホスト): `$BUILDPLATFORM` は `linux/arm64` に解決される → ネイティブビルド
 
 が両立する。過去に `--platform=linux/amd64` 固定にしていた時期があるが、QEMU エミュレーションで Vite ビルドが `EISDIR` になる問題の回避が目的だった ([fe770ad](https://github.com/ansanloms/mirakc-ui/commit/fe770ad), [c5ee238](https://github.com/ansanloms/mirakc-ui/commit/c5ee238))。現在は `$BUILDPLATFORM` 化で両対応 ([#14](https://github.com/ansanloms/mirakc-ui/pull/14))。
 
-## トランスコード層採用時の差分
+## トランスコード層の設計方針
 
-- [#11 A 方式](https://github.com/ansanloms/mirakc-ui/issues/11) を採用する場合はこの最終ステージに `ffmpeg` / `tsreadex` を追加する
-- [#16 B' 方式](https://github.com/ansanloms/mirakc-ui/issues/16) を採用する場合は Dockerfile は触らず、mirakc 側の `post-filters` 設定で扱う
+現行 Dockerfile は A 方式 (mirakc-ui 内部で ffmpeg/tsreadex を実行) 前提で tsreadex / ffmpeg を同梱している。B' 方式 (mirakc の `post-filters` に寄せる、[#16](https://github.com/ansanloms/mirakc-ui/issues/16)) を採用する場合は Dockerfile から `tsreadex-build` ステージと ffmpeg apt インストールを削除してスリム化できる。採用方針は [#11](https://github.com/ansanloms/mirakc-ui/issues/11) / [#16](https://github.com/ansanloms/mirakc-ui/issues/16) で継続検討中。

--- a/.claude/rules/env.md
+++ b/.claude/rules/env.md
@@ -1,0 +1,4 @@
+# 環境変数
+
+- `MIRAKC_API_URL` — mirakc API のベース URL（例: `http://mirakc:40772/api`）。`.env`（ホスト実行時）または `.devcontainer/.env`（devcontainer）に設定。
+- `VITE_ALLOWED_HOSTS` — Vite dev サーバの `server.allowedHosts` を env から設定する。カンマ区切りのホスト名（例: `raspberrypi.local,.local`）、または `true` / `all` で全許可。未設定なら Vite デフォルト動作。Raspberry Pi 等の非 localhost 経由で開発サーバにアクセスする場合に使用する。

--- a/.claude/rules/pr-review.md
+++ b/.claude/rules/pr-review.md
@@ -1,0 +1,33 @@
+# Pull Request / Issue の Claude レビュー
+
+`anthropics/claude-code-action` を 2 本の GitHub Actions で運用している。
+
+- `.github/workflows/claude-code-review.yml` — PR が `opened` / `synchronize` / `ready_for_review` / `reopened` の時に**自動**で `/code-review:code-review` を実行する。PR 作成直後に必ず走るので、手動トリガは不要。
+- `.github/workflows/claude.yml` — Issue / PR / レビュー / コメントに `@claude` メンションが含まれると起動する対話型。自動レビューとは別に、設計視点の依頼・追加質問・具体の観点を指定したレビューを回したい場合はこちらを使う。
+
+## 手順: PR を作成したら Claude にレビュー依頼する
+
+1. `gh pr create ...` で PR を作成する（この時点で `claude-code-review` が自動起動する）。
+2. PR 本体のコメントで `@claude` メンションを含むレビュー依頼を投稿する。観点を箇条書きで指定するとレビューが刺さりやすい。
+
+```
+@claude レビューお願い。
+
+特に見てほしい観点:
+
+1. ...
+2. ...
+```
+
+3. Claude のレビューコメントが付いたら、必要に応じて追加コメントで `@claude` メンションして質問・修正依頼する。
+4. レビュー結果をもとにコミット → push すれば、`claude-code-review.yml` が `synchronize` で再実行される。
+
+## Issue でも同様に
+
+Issue のタイトルや本文に `@claude` を含めると `claude.yml` が起動する。複雑な仕様調査や設計相談を Issue ベースで回したい場合に有用。
+
+## 観点を示すコツ
+
+- 「UI の妥当性」より「`islands/Watch.tsx:33-44` の初期化ロジックが render 中 setState になっていないか」のように**ファイル+行+具体観点**を書く
+- 優先度表 (要修正 / 推奨 / 任意 / 参考) を期待するとレビュー側もその粒度で返してくる
+- 返ってきた指摘の **スコープ外**判断は別 issue に切り出して明示すると整理される

--- a/.claude/rules/project.md
+++ b/.claude/rules/project.md
@@ -1,0 +1,26 @@
+# プロジェクト概要
+
+[mirakc](https://github.com/mirakc/mirakc) 向けの Web UI。番組表閲覧、録画管理、番組検索機能を提供する。ライブ視聴機能は UI 骨組みが先行で入っており、トランスコード層は [issue #11 (A 方式)](https://github.com/ansanloms/mirakc-ui/issues/11) / [issue #16 (B' 方式)](https://github.com/ansanloms/mirakc-ui/issues/16) で別途検討中。
+
+## テックスタック
+
+- **フレームワーク**: Fresh 2.x（Deno ベース）
+- **UI**: Preact + @preact/signals
+- **ビルド**: Vite（`vite.config.ts` に CSS 強制注入カスタムプラグインあり）
+- **ランタイム**: Deno 2.x
+- **API クライアント**: openapi-fetch + openapi-typescript による型安全な API 呼び出し
+- **国際化**: i18next（日本語のみ）
+- **スタイリング**: CSS モジュール + グローバル CSS 変数（ライト/ダークモード対応）
+
+## コマンド
+
+```bash
+deno task dev        # 開発サーバー起動（vite、ポート 5173）
+deno task build      # 本番ビルド（_fresh/ に出力）
+deno task start      # ビルド済みアプリを起動（deno serve）
+deno task check      # fmt チェック + lint + 型チェック（CI 相当）
+deno task fix        # deno lint --fix + deno fmt で自動修正
+deno task generate   # OpenAPI スキーマから hooks/api/schema.d.ts を再生成
+```
+
+lint プラグインとして `@aireone/deno-lint-curly` を使用しており、1 行の `if` でも波括弧が必須。`deno task check` が失敗したら `deno task fix` で多くは解消する。

--- a/.claude/rules/tips.md
+++ b/.claude/rules/tips.md
@@ -60,12 +60,19 @@ const responseBody = new ReadableStream<Uint8Array>({
     try {
       while (true) {
         const { done, value } = await reader.read();
-        if (done) { controller.close(); return; }
+        if (done) {
+          controller.close();
+          return;
+        }
         controller.enqueue(value);
       }
-    } catch (e) { controller.error(e); }
+    } catch (e) {
+      controller.error(e);
+    }
   },
-  cancel() { cleanup("response body cancel"); },
+  cancel() {
+    cleanup("response body cancel");
+  },
 });
 ```
 
@@ -98,6 +105,17 @@ const responseBody = new ReadableStream<Uint8Array>({
 - PR ブランチを main と同期するときは rebase ではなく merge commit で十分 (CI の synchronize が自動再走するため)。
 - destructive な操作 (`git reset --hard`, `git push --force`) は明示指示が無ければ避ける。
 
-## Claude Code Review 運用の tips
+## 動作確認のアプローチ (自動テスト無し前提)
 
-`.claude/rules/pr-review.md` 参照。
+本リポジトリには自動テストスイートが存在しない。機能確認は以下の手順で行う。
+
+1. **devcontainer の dev サーバ起動**: `.devcontainer/compose.yaml` の `app` サービスが `deno task dev --host 0.0.0.0` を起動する。VS Code で "Reopen in Container" するか、CLI で `devcontainer up --workspace-folder .`。
+2. **ホスト名経由のアクセス**: Raspberry Pi 等のリモート環境で開発する場合は `VITE_ALLOWED_HOSTS` env を設定した上で `http://<host>:5173/` にブラウザでアクセス。
+3. **ブラウザ DevTools で検証**: Chrome の DevTools (`mcp__chrome-devtools__*` MCP が使える環境なら Claude Code からも操作可) で以下を観察する。
+   - Console タブ: エラー / 警告の発生状況
+   - Network タブ: API リクエストのステータス、ストリームの `Content-Type`、レスポンスサイズ
+   - Elements タブ: `<video>` / `<canvas>` / state を反映した DOM 属性
+4. **サーバログの確認**: `docker logs mirakc-ui-app-1` で vite / deno のログ、tsreadex / ffmpeg / encoder-probe の stderr を追う。
+5. **サービスプロセスの確認**: `pgrep -af 'ffmpeg|tsreadex'` でゾンビ子プロセスの有無を確認する。client 切断後も残っている場合はクリーンアップが効いていない。
+
+`deno task check` は CI 相当のチェックだが型 / lint / fmt のみで機能回帰までは見ない。UI / ストリーム挙動は毎回ブラウザで目視すること。

--- a/.claude/rules/tips.md
+++ b/.claude/rules/tips.md
@@ -1,0 +1,103 @@
+# 実装・運用の知見
+
+## devcontainer の vite (app) が `deno task check/fix` で crash する
+
+### 症状
+
+ホスト側で `deno task check` や `deno task fix` を実行すると、しばらくして devcontainer の `app` コンテナ (vite dev server) が以下のようなエラーで停止する。
+
+```
+error: Uncaught NotFound: No such file or directory (os error 2) about
+  ["/app/components/.../SomeFile.tsx.tmp.<pid>.<ts>"]
+    at new FsWatcher (ext:runtime/40_fs_events.js:23:17)
+    ...
+```
+
+`deno fmt` が一時ファイル (`.tmp.<pid>.<timestamp>`) を作って即 rename で削除するが、devcontainer 内の Fresh プラグイン（`@fresh/plugin-vite`）の FsWatcher が監視開始する前に元ファイルが消えて NotFound → uncaught で deno プロセス終了、という流れ。
+
+### 対処
+
+一時的には次で復旧する。
+
+```sh
+docker compose --project-name mirakc-ui -f .devcontainer/compose.yaml restart app
+```
+
+恒常的には以下のいずれか:
+
+- `deno task check/fix` は devcontainer の `app` を停止した状態で実行する (ホスト側で fmt が終わってから `restart app`)
+- または `check/fix` をホスト側でなく devcontainer 内部の別シェルで実行する (vite 本体とは別プロセスになり FsWatcher 競合を起こしにくい)
+
+`.gitignore` に `*.tmp.*` を足しても Fresh 側の watcher 抑制にはならない (watcher は git 無関係)。
+
+## Preact / Fresh の hook 規約
+
+- **render body 内で `setState` を呼ばない** — React/Preact のアンチパターン。`useEffect` に寄せる。例: API データ到着時の初期化処理は `[data, loading]` 等に依存する `useEffect` で実行する。
+- **リスト要素には `key` prop を必ず指定する** — `Array.map()` で `<section>` や `<li>` 等を返すとき、差分計算が狂う。`key={stableId}` を付ける。
+- `useGet` などの非同期 hook は `{ state, data, error, loading }` のすべての状態を想定した分岐を書く。エラー時に `initialized` フラグが永久 false のまま Loading 画面から抜けられない罠を踏みやすい。
+- 非同期初期化の stale closure 対策には `useRef` を使う。例えば `captionVisible` を effect 内の async 完了後に参照したい場合は `captionVisibleRef.current` パターン。
+
+## Deno のサブプロセス管理 (stream を Response に流す場合)
+
+`Deno.Command(...).spawn()` で子プロセスを spawn し、`child.stdout` を `new Response(...)` の body に渡す構成では、**client が接続を切っても子プロセスが残る** 問題に注意。ffmpeg 等はバッファが埋まって stdout に書けなくなると backpressure でブロックし、プロセスがゾンビ化する。
+
+### 対処パターン
+
+以下 5 経路から冪等な `cleanup(reason)` を発火させる。
+
+1. `ctx.req.signal` の `abort` イベント (client 切断)
+2. `childA.status` resolve (子プロセス終了)
+3. `childB.status` resolve (もう一方の子プロセス終了)
+4. 上流パイプの `.pipeTo(...).catch(...)` 経路
+5. Response body を自前の `ReadableStream` でラップし `UnderlyingSource.cancel` を拾う
+
+`cleanup` は SIGTERM を送り、3 秒後に生存していたら SIGKILL。
+
+```ts
+const responseBody = new ReadableStream<Uint8Array>({
+  async start(controller) {
+    const reader = childA.stdout.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) { controller.close(); return; }
+        controller.enqueue(value);
+      }
+    } catch (e) { controller.error(e); }
+  },
+  cancel() { cleanup("response body cancel"); },
+});
+```
+
+また `stderr` は `piped` にして必ずログに吐くこと。`"null"` だと障害解析ができない。改行単位で `console.error` に流すヘルパを用意するのが定石。
+
+## Deno で外部エンコーダを実 probe 検出する
+
+`ffmpeg -encoders` の文字列一致は**デバイス有無を判定できない**ので誤検出する (Debian の ffmpeg pkg は `h264_v4l2m2m` をビルド済み。ただし `/dev/video*` が無ければ使えない)。
+
+対処: `ffmpeg -f lavfi -i color=... -c:v <encoder> -frames:v 10 -f null -` のような**実エンコードテスト**を 5 秒程度の timeout (`AbortController`) 付きで走らせ、exit code で判定する。
+
+並行リクエストのレースは `let detectingPromise: Promise<...> | null` で直列化。両方失敗時は `null` を返してハンドラ側で 503 応答。`null` はキャッシュしない (プロセス内で ffmpeg 再インストール等の復旧余地を残す)。
+
+## mirakc まわりの運用知見
+
+- `/api/services/:id/stream?decode=1` は **MPEG-2 Video のまま**。ブラウザ (MSE / WebCodecs) では再生できないので、H.264 などへのトランスコード層を挟む必要がある。
+- トランスコード層は mirakc-ui 内で実装する (A 方式) か、mirakc の `post-filters` に寄せる (B' 方式) かで設計が分かれる。`post-filters` はクエリ per-request 指定なので**他クライアント (EPGStation 等) に影響しない**。詳細は [#11](https://github.com/ansanloms/mirakc-ui/issues/11) / [#16](https://github.com/ansanloms/mirakc-ui/issues/16)。
+- tsreadex は ARIB 字幕 PES を ID3 timed-metadata に変換するツール。`aribb24.js` は mpegts.js の `TIMED_ID3_METADATA_ARRIVED` だけでなく `PES_PRIVATE_DATA_ARRIVED` 経由でも字幕を受けられるため、tsreadex 無しでも描画できる可能性がある (要実機検証)。
+
+## Raspberry Pi 5 特有
+
+- **H.264 HW encoder 非搭載** (BCM2712 から削除)。Pi 4 までは `h264_v4l2m2m` が使えたが、Pi 5 では encode/decode ともに CPU 処理になる。
+- libx264 `-preset ultrafast -tune zerolatency` で 720p リアルタイム 1 ストリームは実用、1080p は 1〜2 ストリームが限度。
+- `/dev/video*` が存在しても encoder として使えない点に注意 (Pi 4 前提の検出ロジックを使い回すと誤判定する)。
+
+## Git 運用の小ネタ
+
+- ローカルの追跡切れブランチは `git branch -vv` で `[origin/xxx: gone]` を確認してから `git branch -D` で削除。
+- 機能領域を分割して PR を起こしたい時は、`git checkout <source-branch> -- <path>` でファイル単位の取り込みが使える。cherry-pick より差分が明確。
+- PR ブランチを main と同期するときは rebase ではなく merge commit で十分 (CI の synchronize が自動再走するため)。
+- destructive な操作 (`git reset --hard`, `git push --force`) は明示指示が無ければ避ける。
+
+## Claude Code Review 運用の tips
+
+`.claude/rules/pr-review.md` 参照。

--- a/.claude/rules/watch.md
+++ b/.claude/rules/watch.md
@@ -1,32 +1,36 @@
-# ライブ視聴
+# ライブ視聴とトランスコード
 
 ## ページ構成
 
-- `/watch` — サービス一覧
-- `/watch/[serviceId]` — プレイヤー
-- `islands/Watch.tsx` がプレイヤー島、`components/organisms/Watch/` に UI 部品
+- `/watch/[serviceId]`。`islands/Watch.tsx` がプレイヤー島、`components/organisms/Watch/` に UI 部品。
 
-## ストリーム
+## トランスコード API
 
-現状は `/api/mirakc/services/:id/stream?decode=1`（mirakc 生ストリーム、MPEG-2 Video）を直接プロキシするのみ。ブラウザ（MSE）では映像は再生できない。Player 上部に「視聴機能は別 PR で実装予定」の告知を表示する。トランスコード層は [#11 (A 方式)](https://github.com/ansanloms/mirakc-ui/issues/11) または [#16 (B' 方式)](https://github.com/ansanloms/mirakc-ui/issues/16) で別途実装する想定。
+`routes/api/transcode/services/[id].ts`。パイプラインは mirakc のサービスストリーム → `tsreadex`（字幕・音声整形）→ `ffmpeg`（H.264 / AAC に再エンコード）→ MPEG-TS をチャンク応答。
 
-## 再生ライブラリ
+## 再生
 
-- `mpegts.js`（MSE）で `<video>` にアタッチ
+- `mpegts.js`（MSE ベース）で `<video>` にアタッチ
 - `aribb24.js` で ARIB 字幕を canvas オーバーレイ
-- 映像トランスコードが未配線でも、字幕 PES が含まれていれば aribb24.js 経由で canvas に描画される場合がある (mpegts.js の `PES_PRIVATE_DATA_ARRIVED` → `feedB24`)
+
+## HW エンコーダー自動検出
+
+起動時に `h264_v4l2m2m` と `libx264` を順に**実エンコードテスト (probe)** で検証し、成功した方をキャッシュ。WSL2 等でカーネルモジュール不在の場合は `libx264` にフォールバック。両方失敗時は `503 No usable H.264 encoder found` を返す。
+
+## デバッグログ
+
+tsreadex / ffmpeg / encoder-probe の stderr は `[tsreadex]` / `[ffmpeg]` / `[encoder-probe ${name}]` のプレフィックス付きで `console.error` に出力する (`docker logs mirakc-ui-app-1` で確認可)。
 
 ## URL 状態管理
 
 - `serviceId` はパスパラメータ
 - `audioTrack` / `quality` / `caption` はクエリパラメータ
-- トランスコード層が入ると `audioTrack` / `quality` が `streamUrl` に反映される（現状は UI 上の state のみ、ボタンは disabled 固定）
-
-## サービス一覧
-
-物理チャンネル (`channel.type` + `channel.channel`) + サービス名の組で重複排除する（mirakc は 1 物理チャンネルに主サービス / 副サービス / 1 セグ等を別 serviceId として返すため）。
 
 ## 既知の制限
 
 - ブラウザウィンドウを拡大しすぎると ARIB 字幕がほぼ表示されなくなる（aribb24.js 2.0.12 の magnification バグ、[issue #15](https://github.com/ansanloms/mirakc-ui/issues/15)）。字幕を見たい場合はウィンドウ幅を 1280px 程度に抑える。
-- アクセシビリティ（クリッカブル div 等）の棚卸しは [issue #19](https://github.com/ansanloms/mirakc-ui/issues/19) で別途対応予定。
+- アクセシビリティ (クリッカブル div 等) の棚卸しは [issue #19](https://github.com/ansanloms/mirakc-ui/issues/19) で別途対応予定。
+
+## 実装の別方針検討中
+
+ffmpeg / tsreadex を mirakc-ui 内で実行する現状 (A 方式) に加え、mirakc の `post-filters` に変換を寄せる B' 方式を [#16](https://github.com/ansanloms/mirakc-ui/issues/16) で検討中。UI 層だけを先行して確定させる試みが [PR #18](https://github.com/ansanloms/mirakc-ui/pull/18) にある。

--- a/.claude/rules/watch.md
+++ b/.claude/rules/watch.md
@@ -1,0 +1,32 @@
+# ライブ視聴
+
+## ページ構成
+
+- `/watch` — サービス一覧
+- `/watch/[serviceId]` — プレイヤー
+- `islands/Watch.tsx` がプレイヤー島、`components/organisms/Watch/` に UI 部品
+
+## ストリーム
+
+現状は `/api/mirakc/services/:id/stream?decode=1`（mirakc 生ストリーム、MPEG-2 Video）を直接プロキシするのみ。ブラウザ（MSE）では映像は再生できない。Player 上部に「視聴機能は別 PR で実装予定」の告知を表示する。トランスコード層は [#11 (A 方式)](https://github.com/ansanloms/mirakc-ui/issues/11) または [#16 (B' 方式)](https://github.com/ansanloms/mirakc-ui/issues/16) で別途実装する想定。
+
+## 再生ライブラリ
+
+- `mpegts.js`（MSE）で `<video>` にアタッチ
+- `aribb24.js` で ARIB 字幕を canvas オーバーレイ
+- 映像トランスコードが未配線でも、字幕 PES が含まれていれば aribb24.js 経由で canvas に描画される場合がある (mpegts.js の `PES_PRIVATE_DATA_ARRIVED` → `feedB24`)
+
+## URL 状態管理
+
+- `serviceId` はパスパラメータ
+- `audioTrack` / `quality` / `caption` はクエリパラメータ
+- トランスコード層が入ると `audioTrack` / `quality` が `streamUrl` に反映される（現状は UI 上の state のみ、ボタンは disabled 固定）
+
+## サービス一覧
+
+物理チャンネル (`channel.type` + `channel.channel`) + サービス名の組で重複排除する（mirakc は 1 物理チャンネルに主サービス / 副サービス / 1 セグ等を別 serviceId として返すため）。
+
+## 既知の制限
+
+- ブラウザウィンドウを拡大しすぎると ARIB 字幕がほぼ表示されなくなる（aribb24.js 2.0.12 の magnification バグ、[issue #15](https://github.com/ansanloms/mirakc-ui/issues/15)）。字幕を見たい場合はウィンドウ幅を 1280px 程度に抑える。
+- アクセシビリティ（クリッカブル div 等）の棚卸しは [issue #19](https://github.com/ansanloms/mirakc-ui/issues/19) で別途対応予定。


### PR DESCRIPTION
## Summary

- CLAUDE.md が肥大化したため、Claude Code の `@import` 記法を使って `.claude/rules/` 配下にトピック別に分割する。
- 併せて今回のセッションで得られた運用知見を `rules/tips.md` / `rules/devcontainer.md` に追記する。

## 構成

| ファイル | 内容 |
|---|---|
| `.claude/CLAUDE.md` | エントリポイント。`@./rules/*.md` を列挙し、ルール構成の早見表を置くのみ |
| `rules/project.md` | プロジェクト概要 / テックスタック / コマンド |
| `rules/architecture.md` | Fresh Island / API プロキシ / API フック / スタイリング / 国際化 |
| `rules/watch.md` | ライブ視聴 UI の設計と既知の制限 |
| `rules/env.md` | 環境変数 |
| `rules/devcontainer.md` | devcontainer のセットアップと注意事項 |
| `rules/docker.md` | 本番 Docker のステージ構成と `$BUILDPLATFORM` 運用 |
| `rules/deno.md` | Deno 設定の注意点 |
| `rules/pr-review.md` | Claude Code Review の運用手順 |
| `rules/tips.md` | 実装・運用の知見 |

## 追記した運用知見 (主に `rules/tips.md`)

- ホスト側で `deno task check/fix` を実行すると devcontainer の `app` (vite) が Fresh FsWatcher の NotFound で crash する罠と対処
- Preact / Fresh の hook 規約 (render 内 setState 禁止、`key` 必須、`useGet` の error 分岐を忘れない)
- Deno のサブプロセス管理と stream ベースの Response body で子プロセスがゾンビ化する問題の 5 経路 cleanup パターン
- 外部エンコーダ (ffmpeg `h264_v4l2m2m` 等) の実 probe 検出パターン
- mirakc の stream 仕様と `post-filters` のスコープ
- Raspberry Pi 5 の H.264 HW encoder 非搭載事情
- Git 運用の小ネタ
- 動作確認のアプローチ (自動テスト無し前提の手順)

## Claude レビュー対応

初回レビュー ([comment](https://github.com/ansanloms/mirakc-ui/pull/20#issuecomment-4285287906)) で以下を指摘されて対応済 (コミット `52c9d43`):

- 🔴 要修正: `rules/docker.md` のステージ構成が main の Dockerfile 実態と乖離 → 3 ステージ構成 + ffmpeg/tsreadex 記述を復元
- 🔴 要修正: `rules/watch.md` から transcode API / HW encoder 検出 / デバッグログ prefix が抜けていた → 復元
- 🟡 推奨: `rules/tips.md` 末尾「Claude Code Review 運用の tips」空セクション削除
- 🟢 任意: `rules/tips.md` に「動作確認のアプローチ (自動テスト無し前提)」セクションを追加

Claude の推奨「`env.md` / `deno.md` を `project.md` に統合」は採用せず独立維持 (将来追記前提)。CLAUDE.md に独立維持方針を 1 行明記。

## PR #18 マージ後の更新 TODO

[PR #18](https://github.com/ansanloms/mirakc-ui/pull/18) (UI 骨組み先行マージ) がマージされた後、本 PR の内容と齟齬が出るため以下のアップデートが必要:

- [ ] `rules/watch.md` のストリーム節を UI-only 前提に書き直す (現在は main 実態の A 方式記述)
- [ ] `rules/docker.md` の最終ステージから tsreadex/ffmpeg 記述を削除または「採用方針が決まるまで残す」と明記する
- [ ] `rules/watch.md` の「既知の制限」にサービス重複排除の実装 (PR #18 で追加) への言及を追加
- [ ] もしくは PR #18 側で `.claude/` 配下の更新も同梱する

PR #20 と PR #18 のどちらが先にマージされてもかまわないが、conflict が発生した場合は**本 PR (#20) を先にマージして後続 PR で rules 側を更新**するのが手戻り少。

## Test plan

- [ ] `deno task check` が通ること (md ファイルは fmt/lint 対象外だが念のため)
- [ ] Claude Code が新 CLAUDE.md を起動時に正しく読み込み、rules 配下の内容に基づいて作業できること
- [ ] GitHub Actions の `claude-code-review` / `build-and-push-image` が成功すること

## 関連

- 本セッションの知見をまとめたもの
- [PR #18](https://github.com/ansanloms/mirakc-ui/pull/18) (ライブ視聴 UI 骨組み) マージ後に `rules/watch.md` / `rules/docker.md` の更新が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)