### PR TITLE
fix: 番組表ヘッダのすりガラスを有効化し cornerHead の時刻表示を削除

### DIFF
--- a/client/assets/styles/palette.css
+++ b/client/assets/styles/palette.css
@@ -140,7 +140,11 @@
   --color-recording-border: var(--color-now);
 
   /* ---- glass / shadow / scrim (テーマ差は light-dark でインライン) ---- */
-  --glass-blur: light-dark(saturate(1.4) blur(9px), saturate(1.3) blur(10px));
+  /* light-dark() は <color> / <image> 専用で filter 値には使えない。
+     かつて light-dark(saturate(...) blur(...), ...) としていたが値ごと破棄され
+     backdrop-filter が無効化されていた。単一の filter 値に統一する
+     (light/dark の blur 量差は視認できないため、テーマ差は持たせない)。 */
+  --glass-blur: saturate(1.3) blur(10px);
   --shadow-modal: light-dark(
     0 24px 70px rgba(18, 24, 45, 0.28),
     0 28px 80px rgba(0, 0, 0, 0.6)

--- a/client/components/organisms/Program/Table.tsx
+++ b/client/components/organisms/Program/Table.tsx
@@ -87,9 +87,7 @@ export default function ProgramTable(props: Props) {
           }, ${SERVICE_COL}rem)`,
         }}
       >
-        <div className={styles.cornerHead}>
-          {formatH(fromMs)}時
-        </div>
+        <div className={styles.cornerHead} />
 
         {services.map((service, index) => (
           <Link


### PR DESCRIPTION
## 概要

番組表ヘッダ (`client/components/organisms/Program/Table.tsx`) のすりガラスが効いていなかった不具合を修正し、あわせて cornerHead に直接表示していた時刻 (n時) を削除する。

## 背景 / 問題

`Table.module.css` の 3 ヘッダ (cornerHead / serviceHeader / timeCell) は `backdrop-filter: var(--glass-blur)` ですりガラスを意図していたが、実機ではぼかしが効かず、半透明の塗りだけが残る状態だった。

原因は `palette.css` の変数定義:

```css
--glass-blur: light-dark(saturate(1.4) blur(9px), saturate(1.3) blur(10px));
```

`light-dark()` は CSS Color の関数で `<color>` / `<image>` 専用であり、`filter` / `backdrop-filter` の値リスト (`saturate() blur()`) には使えない。無効値のため `backdrop-filter` 宣言ごと破棄され、blur が一切効いていなかった。一方 `--color-surface-glass` も `light-dark()` だがこちらは `<color>` のため有効で、「半透明にはなるが blur だけ効かない」という部分的な壊れ方になっていた。

参考: [MDN light-dark()](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark) — two `<color>` values または two `<image>` values のみを受け付ける。

## 変更点

- **`client/assets/styles/palette.css`**: `--glass-blur` から `light-dark()` を除去し、単一の filter 値 `saturate(1.3) blur(10px)` に統一。これで `var(--glass-blur)` を使う番組表の 3 ヘッダ (チャンネル名・時刻列・左上角) のすりガラスが有効になる。light/dark の blur 量差 (9px/10px) は視認できないため、テーマ差は持たせない (テーマ切り替えは手動 ColorSchemeToggle + `color-scheme` 追従の `light-dark()` 方式で color トークンに限定し、OS 追従の `@media` は混ぜない)。
- **`client/components/organisms/Program/Table.tsx`**: cornerHead に直接出していた開始時刻 (`{formatH(fromMs)}時`) を削除。時刻は左の時刻列ヘッダに表示されており重複していた。要素自体はすりガラスの角として残し、列/行ヘッダの交点がスクロール時に透けないようにする。

## 確認

- `deno task check` (型チェック) パス
- `deno task lint` (lint + fmt チェック) パス
- `Table.test.tsx` パス (2 件)
- **未確認**: すりガラスの実機描画。修正の根拠は MDN 仕様と「半透明は効くが blur だけ死ぬ」という観測の一致だが、ブラウザでの目視確認をお願いしたい。

Generated with [Claude Code](https://claude.com/claude-code)
