### PR TITLE
feat: 設定・視聴のヘッダナビゲーションを全画面で統一

### DIFF
--- a/client/components/organisms/PageHeader.module.css
+++ b/client/components/organisms/PageHeader.module.css
@@ -1,0 +1,87 @@
+/* 設定系ページ・視聴ページで共通のヘッダ骨格。
+   mark + titles + right (ナビゲーションリンク群) で構成する。 */
+.toolbar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+  padding: 0 2rem;
+  height: 6rem;
+  background: var(--color-surface);
+  box-shadow: 0 1px 0 var(--color-border), var(--shadow-toolbar);
+  position: relative;
+  z-index: var(--z-index-toolbar);
+}
+
+.mark {
+  flex: 0 0 auto;
+  width: 3.6rem;
+  height: 3.6rem;
+  border-radius: 0.8rem;
+  background: color-mix(in srgb, var(--color-accent) 13%, transparent);
+  color: var(--color-accent);
+  display: grid;
+  place-items: center;
+}
+
+.titles {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+  min-width: 0;
+}
+
+.title {
+  margin: 0;
+  font-weight: 700;
+  font-size: 1.5rem;
+  letter-spacing: 0.02rem;
+  white-space: nowrap;
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--color-text-dim);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+}
+
+/* 枠付きの正方形アイコンリンク。 */
+.link {
+  display: grid;
+  place-items: center;
+  width: 3.6rem;
+  height: 3.6rem;
+  border-radius: 0.8rem;
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-surface);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background 0.12s;
+
+  &:hover {
+    background: var(--color-surface-2);
+  }
+}
+
+/* ---- mobile ---- */
+@container style(--is-mobile: true) {
+  .toolbar {
+    padding: 0 1.2rem;
+    gap: 0.8rem;
+  }
+
+  .subtitle {
+    display: none;
+  }
+}

--- a/client/components/organisms/PageHeader.stories.tsx
+++ b/client/components/organisms/PageHeader.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import PageHeader from "./PageHeader.tsx";
+import ColorSchemeToggle from "../../islands/ColorSchemeToggle.tsx";
+
+const meta = {
+  title: "organisms/PageHeader",
+  component: PageHeader,
+  parameters: { layout: "fullscreen" },
+  args: {
+    icon: "settings",
+    title: "設定",
+    subtitle: "録画・通知の設定をまとめて管理",
+    links: [
+      { icon: "grid_view", label: "番組表へ", onClick: () => {} },
+      { icon: "live_tv", label: "視聴画面を開く", onClick: () => {} },
+    ],
+    children: <ColorSchemeToggle />,
+  },
+} satisfies Meta<typeof PageHeader>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+/** リンク 3 つ (設定詳細ページ相当)。 */
+export const ThreeLinks: Story = {
+  args: {
+    icon: "notifications",
+    title: "通知設定",
+    subtitle: "録画イベントを ntfy.sh で通知します",
+    links: [
+      { icon: "grid_view", label: "番組表へ", onClick: () => {} },
+      { icon: "live_tv", label: "視聴画面を開く", onClick: () => {} },
+      { icon: "settings", label: "設定へ", onClick: () => {} },
+    ],
+  },
+};

--- a/client/components/organisms/PageHeader.test.tsx
+++ b/client/components/organisms/PageHeader.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import PageHeader from "./PageHeader.tsx";
+
+function setup(override: Partial<Parameters<typeof PageHeader>[0]> = {}) {
+  const onBack = vi.fn();
+  const onWatch = vi.fn();
+  const props = {
+    icon: "settings",
+    title: "設定",
+    subtitle: "サブタイトル",
+    links: [
+      { icon: "grid_view", label: "番組表へ", onClick: onBack },
+      { icon: "live_tv", label: "視聴画面を開く", onClick: onWatch },
+    ],
+    ...override,
+  };
+  return { ...render(<PageHeader {...props} />), onBack, onWatch };
+}
+
+describe("PageHeader", () => {
+  it("タイトル・サブタイトルを描画する", () => {
+    setup();
+    expect(screen.getByText("設定")).toBeTruthy();
+    expect(screen.getByText("サブタイトル")).toBeTruthy();
+  });
+
+  it("links を aria-label 付きアイコンボタンとして描画する", () => {
+    setup();
+    expect(screen.getByLabelText("番組表へ")).toBeTruthy();
+    expect(screen.getByLabelText("視聴画面を開く")).toBeTruthy();
+  });
+
+  it("リンクのクリックで対応する onClick が発火する", () => {
+    const { onBack, onWatch } = setup();
+    fireEvent.click(screen.getByLabelText("番組表へ"));
+    expect(onBack).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByLabelText("視聴画面を開く"));
+    expect(onWatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("children (スロット) を描画する", () => {
+    setup({ children: <div data-testid="slot">slot</div> });
+    expect(screen.getByTestId("slot")).toBeTruthy();
+  });
+});

--- a/client/components/organisms/PageHeader.tsx
+++ b/client/components/organisms/PageHeader.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from "react";
+import Icon from "../atoms/Icon.tsx";
+import styles from "./PageHeader.module.css";
+
+/** ヘッダ右側のナビゲーションリンク (アイコンのみ)。 */
+export type PageHeaderLink = {
+  /** Material Symbols のアイコン名。 */
+  icon: string;
+  /** アクセシブルなラベル (aria-label)。 */
+  label: string;
+  /** クリック時の遷移処理。 */
+  onClick: () => void;
+};
+
+type Props = {
+  /** 左端の mark に表示する Material Symbols アイコン名。 */
+  icon: string;
+
+  /** ページタイトル。 */
+  title: string;
+
+  /** サブタイトル (モバイルでは非表示)。 */
+  subtitle: string;
+
+  /** 右側のナビゲーションリンク群。各ページは自身に当たるリンクを省いて渡す。 */
+  links: PageHeaderLink[];
+
+  /** right 末尾に差し込むスロット (ColorSchemeToggle 等)。 */
+  children?: ReactNode;
+};
+
+/**
+ * 設定系ページ・視聴ページで共通のページヘッダ。
+ * mark (アイコン) + タイトル / サブタイトル + 右ナビゲーションリンク群 + スロット
+ * で構成する。リンクはデータ駆動 (links) で受け取り、各ページは自身に当たる
+ * リンクを省いて渡す。
+ */
+export default function PageHeader(props: Props) {
+  return (
+    <header className={styles.toolbar}>
+      <span className={styles.mark}>
+        <Icon size={20}>{props.icon}</Icon>
+      </span>
+      <div className={styles.titles}>
+        <h1 className={styles.title}>{props.title}</h1>
+        <p className={styles.subtitle}>{props.subtitle}</p>
+      </div>
+      <div className={styles.right}>
+        {props.links.map((link) => (
+          <button
+            key={link.label}
+            type="button"
+            className={styles.link}
+            onClick={link.onClick}
+            aria-label={link.label}
+          >
+            <Icon size={18}>{link.icon}</Icon>
+          </button>
+        ))}
+        {props.children}
+      </div>
+    </header>
+  );
+}

--- a/client/components/organisms/Program/Toolbar.stories.tsx
+++ b/client/components/organisms/Program/Toolbar.stories.tsx
@@ -12,6 +12,7 @@ const meta = {
     onChangeDate: () => {},
     onChangeChannelType: () => {},
     onOpenSearch: () => {},
+    onOpenWatch: () => {},
     onOpenSettings: () => {},
   },
 } satisfies Meta<typeof ProgramToolbar>;

--- a/client/components/organisms/Program/Toolbar.test.tsx
+++ b/client/components/organisms/Program/Toolbar.test.tsx
@@ -18,6 +18,7 @@ function setup(
     channelType: "GR" as const,
     onChangeChannelType: vi.fn(),
     onOpenSearch: vi.fn(),
+    onOpenWatch: vi.fn(),
     onOpenSettings: vi.fn(),
     now: today,
     ...override,
@@ -37,7 +38,8 @@ describe("ProgramToolbar", () => {
     }
     // SearchTrigger
     expect(screen.getByText(t("program.toolbar.search"))).toBeTruthy();
-    // 設定ポータルへの歯車
+    // 視聴画面への live_tv / 設定ポータルへの歯車
+    expect(screen.getByLabelText(t("watch.open"))).toBeTruthy();
     expect(screen.getByLabelText(t("settings.open"))).toBeTruthy();
   });
 
@@ -47,6 +49,8 @@ describe("ProgramToolbar", () => {
     expect(props.onOpenSearch).toHaveBeenCalledTimes(1);
     fireEvent.click(screen.getByText(channelTypeLabel("BS")));
     expect(props.onChangeChannelType).toHaveBeenCalledWith("BS");
+    fireEvent.click(screen.getByLabelText(t("watch.open")));
+    expect(props.onOpenWatch).toHaveBeenCalledTimes(1);
     fireEvent.click(screen.getByLabelText(t("settings.open")));
     expect(props.onOpenSettings).toHaveBeenCalledTimes(1);
   });

--- a/client/components/organisms/Program/Toolbar.tsx
+++ b/client/components/organisms/Program/Toolbar.tsx
@@ -23,6 +23,9 @@ type Props = {
   /** 検索モーダルを開く。 */
   onOpenSearch: () => void;
 
+  /** 視聴画面 (/watch) を開く。 */
+  onOpenWatch: () => void;
+
   /** 設定ポータル (/settings) を開く。キーワード自動録画もここから辿る。 */
   onOpenSettings: () => void;
 
@@ -46,6 +49,11 @@ export default function ProgramToolbar(props: Props) {
       <SearchTrigger onOpen={props.onOpenSearch} />
 
       <div className={styles.right}>
+        <IconButton
+          icon="live_tv"
+          label={t("watch.open")}
+          onClick={props.onOpenWatch}
+        />
         <IconButton
           icon="settings"
           label={t("settings.open")}

--- a/client/components/templates/KeywordRules.module.css
+++ b/client/components/templates/KeywordRules.module.css
@@ -1,77 +1,3 @@
-/* organisms/Program/Toolbar.module.css の .toolbar と同じ寸法・配色。 */
-.toolbar {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  gap: 1.2rem;
-  padding: 0 2rem;
-  height: 6rem;
-  background: var(--color-surface);
-  box-shadow: 0 1px 0 var(--color-border), var(--shadow-toolbar);
-  position: relative;
-  z-index: var(--z-index-toolbar);
-}
-
-.mark {
-  flex: 0 0 auto;
-  width: 3.6rem;
-  height: 3.6rem;
-  border-radius: 0.8rem;
-  background: color-mix(in srgb, var(--color-accent) 13%, transparent);
-  color: var(--color-accent);
-  display: grid;
-  place-items: center;
-}
-
-.titles {
-  display: flex;
-  flex-direction: column;
-  line-height: 1.2;
-  min-width: 0;
-}
-
-.title {
-  margin: 0;
-  font-weight: 700;
-  font-size: 1.5rem;
-  letter-spacing: 0.02rem;
-  white-space: nowrap;
-}
-
-.subtitle {
-  margin: 0;
-  font-size: 1.1rem;
-  color: var(--color-text-dim);
-  font-weight: 500;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.right {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-  gap: 1.2rem;
-}
-
-.epgLink {
-  display: grid;
-  place-items: center;
-  width: 3.6rem;
-  height: 3.6rem;
-  border-radius: 0.8rem;
-  border: 1px solid var(--color-border-strong);
-  background: var(--color-surface);
-  color: var(--color-text);
-  cursor: pointer;
-  transition: background 0.12s;
-
-  &:hover {
-    background: var(--color-surface-2);
-  }
-}
-
 /* ---- ページ本体 ---- */
 .page {
   flex: 1 1 auto;
@@ -188,15 +114,6 @@
 
 /* ---- mobile ---- */
 @container style(--is-mobile: true) {
-  .toolbar {
-    padding: 0 1.2rem;
-    gap: 0.8rem;
-  }
-
-  .subtitle {
-    display: none;
-  }
-
   .pageInner {
     padding: 2rem 1.2rem 8rem;
   }

--- a/client/components/templates/KeywordRules.module.css
+++ b/client/components/templates/KeywordRules.module.css
@@ -56,17 +56,14 @@
 }
 
 .epgLink {
-  display: flex;
-  align-items: center;
-  gap: 0.8rem;
-  padding: 0.8rem 1.2rem;
+  display: grid;
+  place-items: center;
+  width: 3.6rem;
+  height: 3.6rem;
   border-radius: 0.8rem;
   border: 1px solid var(--color-border-strong);
   background: var(--color-surface);
   color: var(--color-text);
-  font-family: inherit;
-  font-size: 1.3rem;
-  font-weight: 600;
   cursor: pointer;
   transition: background 0.12s;
 
@@ -197,10 +194,6 @@
   }
 
   .subtitle {
-    display: none;
-  }
-
-  .epgLinkText {
     display: none;
   }
 

--- a/client/components/templates/KeywordRules.stories.tsx
+++ b/client/components/templates/KeywordRules.stories.tsx
@@ -44,6 +44,7 @@ const meta = {
     onToggle: () => {},
     onRemove: () => {},
     onBackToSettings: () => {},
+    onOpenWatch: () => {},
     onBack: () => {},
   },
 } satisfies Meta<typeof KeywordRulesTemplate>;

--- a/client/components/templates/KeywordRules.stories.tsx
+++ b/client/components/templates/KeywordRules.stories.tsx
@@ -43,6 +43,7 @@ const meta = {
     onEdit: () => {},
     onToggle: () => {},
     onRemove: () => {},
+    onBackToSettings: () => {},
     onBack: () => {},
   },
 } satisfies Meta<typeof KeywordRulesTemplate>;

--- a/client/components/templates/KeywordRules.test.tsx
+++ b/client/components/templates/KeywordRules.test.tsx
@@ -96,13 +96,13 @@ describe("KeywordRules template", () => {
 
   it("番組表へ戻るリンクで onBack が発火する", () => {
     const { props } = setup();
-    fireEvent.click(screen.getByText(t("keyword.toolbar.epg")));
+    fireEvent.click(screen.getByLabelText(t("keyword.toolbar.epg")));
     expect(props.onBack).toHaveBeenCalledTimes(1);
   });
 
   it("設定へ戻るリンクで onBackToSettings が発火する", () => {
     const { props } = setup();
-    fireEvent.click(screen.getByText(t("keyword.toolbar.settings")));
+    fireEvent.click(screen.getByLabelText(t("keyword.toolbar.settings")));
     expect(props.onBackToSettings).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/components/templates/KeywordRules.test.tsx
+++ b/client/components/templates/KeywordRules.test.tsx
@@ -32,6 +32,7 @@ function setup(
     onEdit: vi.fn(),
     onToggle: vi.fn(),
     onRemove: vi.fn(),
+    onBackToSettings: vi.fn(),
     onBack: vi.fn(),
     ...override,
   };
@@ -97,5 +98,11 @@ describe("KeywordRules template", () => {
     const { props } = setup();
     fireEvent.click(screen.getByText(t("keyword.toolbar.epg")));
     expect(props.onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("設定へ戻るリンクで onBackToSettings が発火する", () => {
+    const { props } = setup();
+    fireEvent.click(screen.getByText(t("keyword.toolbar.settings")));
+    expect(props.onBackToSettings).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/components/templates/KeywordRules.test.tsx
+++ b/client/components/templates/KeywordRules.test.tsx
@@ -33,6 +33,7 @@ function setup(
     onToggle: vi.fn(),
     onRemove: vi.fn(),
     onBackToSettings: vi.fn(),
+    onOpenWatch: vi.fn(),
     onBack: vi.fn(),
     ...override,
   };
@@ -104,5 +105,11 @@ describe("KeywordRules template", () => {
     const { props } = setup();
     fireEvent.click(screen.getByLabelText(t("keyword.toolbar.settings")));
     expect(props.onBackToSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it("視聴画面へのリンクで onOpenWatch が発火する", () => {
+    const { props } = setup();
+    fireEvent.click(screen.getByLabelText(t("watch.open")));
+    expect(props.onOpenWatch).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/components/templates/KeywordRules.tsx
+++ b/client/components/templates/KeywordRules.tsx
@@ -108,21 +108,17 @@ export default function KeywordRules(props: Props) {
             type="button"
             className={styles.epgLink}
             onClick={props.onBackToSettings}
+            aria-label={t("keyword.toolbar.settings")}
           >
-            <Icon size={15}>arrow_back</Icon>
-            <span className={styles.epgLinkText}>
-              {t("keyword.toolbar.settings")}
-            </span>
+            <Icon size={18}>settings</Icon>
           </button>
           <button
             type="button"
             className={styles.epgLink}
             onClick={props.onBack}
+            aria-label={t("keyword.toolbar.epg")}
           >
-            <Icon size={15}>grid_view</Icon>
-            <span className={styles.epgLinkText}>
-              {t("keyword.toolbar.epg")}
-            </span>
+            <Icon size={18}>grid_view</Icon>
           </button>
           <ColorSchemeToggle />
         </div>

--- a/client/components/templates/KeywordRules.tsx
+++ b/client/components/templates/KeywordRules.tsx
@@ -48,6 +48,9 @@ type Props = {
   /** 番組表へ戻る。 */
   onBack: () => void;
 
+  /** 視聴画面 (/watch) へ遷移する。 */
+  onOpenWatch: () => void;
+
   /** モーダル用のスロット (子ルートの Outlet を流し込む)。 */
   children?: ReactNode;
 };
@@ -107,18 +110,26 @@ export default function KeywordRules(props: Props) {
           <button
             type="button"
             className={styles.epgLink}
-            onClick={props.onBackToSettings}
-            aria-label={t("keyword.toolbar.settings")}
-          >
-            <Icon size={18}>settings</Icon>
-          </button>
-          <button
-            type="button"
-            className={styles.epgLink}
             onClick={props.onBack}
             aria-label={t("keyword.toolbar.epg")}
           >
             <Icon size={18}>grid_view</Icon>
+          </button>
+          <button
+            type="button"
+            className={styles.epgLink}
+            onClick={props.onOpenWatch}
+            aria-label={t("watch.open")}
+          >
+            <Icon size={18}>live_tv</Icon>
+          </button>
+          <button
+            type="button"
+            className={styles.epgLink}
+            onClick={props.onBackToSettings}
+            aria-label={t("keyword.toolbar.settings")}
+          >
+            <Icon size={18}>settings</Icon>
           </button>
           <ColorSchemeToggle />
         </div>

--- a/client/components/templates/KeywordRules.tsx
+++ b/client/components/templates/KeywordRules.tsx
@@ -42,6 +42,9 @@ type Props = {
   /** ルールを削除する。 */
   onRemove: (rule: KeywordRule) => void;
 
+  /** 設定ポータル (/settings) へ戻る。 */
+  onBackToSettings: () => void;
+
   /** 番組表へ戻る。 */
   onBack: () => void;
 
@@ -101,6 +104,16 @@ export default function KeywordRules(props: Props) {
           <p className={styles.subtitle}>{t("keyword.subtitle")}</p>
         </div>
         <div className={styles.right}>
+          <button
+            type="button"
+            className={styles.epgLink}
+            onClick={props.onBackToSettings}
+          >
+            <Icon size={15}>arrow_back</Icon>
+            <span className={styles.epgLinkText}>
+              {t("keyword.toolbar.settings")}
+            </span>
+          </button>
           <button
             type="button"
             className={styles.epgLink}

--- a/client/components/templates/KeywordRules.tsx
+++ b/client/components/templates/KeywordRules.tsx
@@ -6,6 +6,7 @@ import {
 } from "../../../server/lib/keyword-rules.ts";
 import { buildUpcoming } from "../../lib/keyword-preview.ts";
 import Icon from "../atoms/Icon.tsx";
+import PageHeader from "../organisms/PageHeader.tsx";
 import RuleCard from "../organisms/KeywordRules/RuleCard.tsx";
 import ColorSchemeToggle from "../../islands/ColorSchemeToggle.tsx";
 import { t } from "../../locales/i18n.ts";
@@ -98,42 +99,30 @@ export default function KeywordRules(props: Props) {
 
   return (
     <div className="app-root">
-      <header className={styles.toolbar}>
-        <span className={styles.mark}>
-          <Icon size={20}>label</Icon>
-        </span>
-        <div className={styles.titles}>
-          <h1 className={styles.title}>{t("keyword.title")}</h1>
-          <p className={styles.subtitle}>{t("keyword.subtitle")}</p>
-        </div>
-        <div className={styles.right}>
-          <button
-            type="button"
-            className={styles.epgLink}
-            onClick={props.onBack}
-            aria-label={t("keyword.toolbar.epg")}
-          >
-            <Icon size={18}>grid_view</Icon>
-          </button>
-          <button
-            type="button"
-            className={styles.epgLink}
-            onClick={props.onOpenWatch}
-            aria-label={t("watch.open")}
-          >
-            <Icon size={18}>live_tv</Icon>
-          </button>
-          <button
-            type="button"
-            className={styles.epgLink}
-            onClick={props.onBackToSettings}
-            aria-label={t("keyword.toolbar.settings")}
-          >
-            <Icon size={18}>settings</Icon>
-          </button>
-          <ColorSchemeToggle />
-        </div>
-      </header>
+      <PageHeader
+        icon="label"
+        title={t("keyword.title")}
+        subtitle={t("keyword.subtitle")}
+        links={[
+          {
+            icon: "grid_view",
+            label: t("keyword.toolbar.epg"),
+            onClick: props.onBack,
+          },
+          {
+            icon: "live_tv",
+            label: t("watch.open"),
+            onClick: props.onOpenWatch,
+          },
+          {
+            icon: "settings",
+            label: t("keyword.toolbar.settings"),
+            onClick: props.onBackToSettings,
+          },
+        ]}
+      >
+        <ColorSchemeToggle />
+      </PageHeader>
 
       <main className={styles.page}>
         <div className={styles.pageInner}>

--- a/client/components/templates/Notification.module.css
+++ b/client/components/templates/Notification.module.css
@@ -1,77 +1,3 @@
-/* templates/Settings.module.css と同じツールバー・ページ骨格。 */
-.toolbar {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  gap: 1.2rem;
-  padding: 0 2rem;
-  height: 6rem;
-  background: var(--color-surface);
-  box-shadow: 0 1px 0 var(--color-border), var(--shadow-toolbar);
-  position: relative;
-  z-index: var(--z-index-toolbar);
-}
-
-.mark {
-  flex: 0 0 auto;
-  width: 3.6rem;
-  height: 3.6rem;
-  border-radius: 0.8rem;
-  background: color-mix(in srgb, var(--color-accent) 13%, transparent);
-  color: var(--color-accent);
-  display: grid;
-  place-items: center;
-}
-
-.titles {
-  display: flex;
-  flex-direction: column;
-  line-height: 1.2;
-  min-width: 0;
-}
-
-.title {
-  margin: 0;
-  font-weight: 700;
-  font-size: 1.5rem;
-  letter-spacing: 0.02rem;
-  white-space: nowrap;
-}
-
-.subtitle {
-  margin: 0;
-  font-size: 1.1rem;
-  color: var(--color-text-dim);
-  font-weight: 500;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.right {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-  gap: 1.2rem;
-}
-
-.epgLink {
-  display: grid;
-  place-items: center;
-  width: 3.6rem;
-  height: 3.6rem;
-  border-radius: 0.8rem;
-  border: 1px solid var(--color-border-strong);
-  background: var(--color-surface);
-  color: var(--color-text);
-  cursor: pointer;
-  transition: background 0.12s;
-
-  &:hover {
-    background: var(--color-surface-2);
-  }
-}
-
 /* ---- ページ本体 ---- */
 .page {
   flex: 1 1 auto;
@@ -111,15 +37,6 @@
 
 /* ---- mobile ---- */
 @container style(--is-mobile: true) {
-  .toolbar {
-    padding: 0 1.2rem;
-    gap: 0.8rem;
-  }
-
-  .subtitle {
-    display: none;
-  }
-
   .pageInner {
     padding: 2.4rem 1.2rem 8rem;
   }

--- a/client/components/templates/Notification.module.css
+++ b/client/components/templates/Notification.module.css
@@ -56,17 +56,14 @@
 }
 
 .epgLink {
-  display: flex;
-  align-items: center;
-  gap: 0.8rem;
-  padding: 0.8rem 1.2rem;
+  display: grid;
+  place-items: center;
+  width: 3.6rem;
+  height: 3.6rem;
   border-radius: 0.8rem;
   border: 1px solid var(--color-border-strong);
   background: var(--color-surface);
   color: var(--color-text);
-  font-family: inherit;
-  font-size: 1.3rem;
-  font-weight: 600;
   cursor: pointer;
   transition: background 0.12s;
 
@@ -120,10 +117,6 @@
   }
 
   .subtitle {
-    display: none;
-  }
-
-  .epgLinkText {
     display: none;
   }
 

--- a/client/components/templates/Notification.stories.tsx
+++ b/client/components/templates/Notification.stories.tsx
@@ -20,6 +20,7 @@ const meta = {
     testing: false,
     onSave: () => Promise.resolve(),
     onTest: () => Promise.resolve(),
+    onBackToSettings: () => {},
     onBack: () => {},
   },
 } satisfies Meta<typeof Notification>;

--- a/client/components/templates/Notification.stories.tsx
+++ b/client/components/templates/Notification.stories.tsx
@@ -21,6 +21,7 @@ const meta = {
     onSave: () => Promise.resolve(),
     onTest: () => Promise.resolve(),
     onBackToSettings: () => {},
+    onOpenWatch: () => {},
     onBack: () => {},
   },
 } satisfies Meta<typeof Notification>;

--- a/client/components/templates/Notification.test.tsx
+++ b/client/components/templates/Notification.test.tsx
@@ -132,13 +132,13 @@ describe("Notification template", () => {
 
   it("番組表へ戻るリンクで onBack が発火する", () => {
     const { props } = setup();
-    fireEvent.click(screen.getByText(t("notification.epg")));
+    fireEvent.click(screen.getByLabelText(t("notification.epg")));
     expect(props.onBack).toHaveBeenCalledTimes(1);
   });
 
   it("設定へ戻るリンクで onBackToSettings が発火する", () => {
     const { props } = setup();
-    fireEvent.click(screen.getByText(t("notification.settings")));
+    fireEvent.click(screen.getByLabelText(t("notification.settings")));
     expect(props.onBackToSettings).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/components/templates/Notification.test.tsx
+++ b/client/components/templates/Notification.test.tsx
@@ -12,6 +12,7 @@ function setup(override: Partial<Parameters<typeof Notification>[0]> = {}) {
     onSave: vi.fn(() => Promise.resolve()),
     onTest: vi.fn(() => Promise.resolve()),
     onBackToSettings: vi.fn(),
+    onOpenWatch: vi.fn(),
     onBack: vi.fn(),
     ...override,
   };
@@ -140,5 +141,11 @@ describe("Notification template", () => {
     const { props } = setup();
     fireEvent.click(screen.getByLabelText(t("notification.settings")));
     expect(props.onBackToSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it("視聴画面へのリンクで onOpenWatch が発火する", () => {
+    const { props } = setup();
+    fireEvent.click(screen.getByLabelText(t("watch.open")));
+    expect(props.onOpenWatch).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/components/templates/Notification.test.tsx
+++ b/client/components/templates/Notification.test.tsx
@@ -11,6 +11,7 @@ function setup(override: Partial<Parameters<typeof Notification>[0]> = {}) {
     testing: false,
     onSave: vi.fn(() => Promise.resolve()),
     onTest: vi.fn(() => Promise.resolve()),
+    onBackToSettings: vi.fn(),
     onBack: vi.fn(),
     ...override,
   };
@@ -133,5 +134,11 @@ describe("Notification template", () => {
     const { props } = setup();
     fireEvent.click(screen.getByText(t("notification.epg")));
     expect(props.onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("設定へ戻るリンクで onBackToSettings が発火する", () => {
+    const { props } = setup();
+    fireEvent.click(screen.getByText(t("notification.settings")));
+    expect(props.onBackToSettings).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/components/templates/Notification.tsx
+++ b/client/components/templates/Notification.tsx
@@ -96,19 +96,17 @@ export default function Notification(props: Props) {
             type="button"
             className={styles.epgLink}
             onClick={props.onBackToSettings}
+            aria-label={t("notification.settings")}
           >
-            <Icon size={15}>arrow_back</Icon>
-            <span className={styles.epgLinkText}>
-              {t("notification.settings")}
-            </span>
+            <Icon size={18}>settings</Icon>
           </button>
           <button
             type="button"
             className={styles.epgLink}
             onClick={props.onBack}
+            aria-label={t("notification.epg")}
           >
-            <Icon size={15}>grid_view</Icon>
-            <span className={styles.epgLinkText}>{t("notification.epg")}</span>
+            <Icon size={18}>grid_view</Icon>
           </button>
           <ColorSchemeToggle />
         </div>

--- a/client/components/templates/Notification.tsx
+++ b/client/components/templates/Notification.tsx
@@ -30,6 +30,9 @@ type Props = {
   /** draft の url / token でテスト通知を送る。失敗は reject。 */
   onTest: (target: { url: string; token: string }) => Promise<void>;
 
+  /** 設定ポータル (/settings) へ戻る。 */
+  onBackToSettings: () => void;
+
   /** 番組表へ戻る。 */
   onBack: () => void;
 };
@@ -89,6 +92,16 @@ export default function Notification(props: Props) {
           <p className={styles.subtitle}>{t("notification.subtitle")}</p>
         </div>
         <div className={styles.right}>
+          <button
+            type="button"
+            className={styles.epgLink}
+            onClick={props.onBackToSettings}
+          >
+            <Icon size={15}>arrow_back</Icon>
+            <span className={styles.epgLinkText}>
+              {t("notification.settings")}
+            </span>
+          </button>
           <button
             type="button"
             className={styles.epgLink}

--- a/client/components/templates/Notification.tsx
+++ b/client/components/templates/Notification.tsx
@@ -35,6 +35,9 @@ type Props = {
 
   /** 番組表へ戻る。 */
   onBack: () => void;
+
+  /** 視聴画面 (/watch) へ遷移する。 */
+  onOpenWatch: () => void;
 };
 
 /**
@@ -95,18 +98,26 @@ export default function Notification(props: Props) {
           <button
             type="button"
             className={styles.epgLink}
-            onClick={props.onBackToSettings}
-            aria-label={t("notification.settings")}
-          >
-            <Icon size={18}>settings</Icon>
-          </button>
-          <button
-            type="button"
-            className={styles.epgLink}
             onClick={props.onBack}
             aria-label={t("notification.epg")}
           >
             <Icon size={18}>grid_view</Icon>
+          </button>
+          <button
+            type="button"
+            className={styles.epgLink}
+            onClick={props.onOpenWatch}
+            aria-label={t("watch.open")}
+          >
+            <Icon size={18}>live_tv</Icon>
+          </button>
+          <button
+            type="button"
+            className={styles.epgLink}
+            onClick={props.onBackToSettings}
+            aria-label={t("notification.settings")}
+          >
+            <Icon size={18}>settings</Icon>
           </button>
           <ColorSchemeToggle />
         </div>

--- a/client/components/templates/Notification.tsx
+++ b/client/components/templates/Notification.tsx
@@ -4,7 +4,7 @@ import {
   NOTIFICATION_EVENT_KEYS,
   type NotificationSettings,
 } from "../../../server/lib/notification-settings.ts";
-import Icon from "../atoms/Icon.tsx";
+import PageHeader from "../organisms/PageHeader.tsx";
 import Toast from "../molecules/Toast.tsx";
 import ServerCard from "../organisms/Notification/ServerCard.tsx";
 import EventToggles from "../organisms/Notification/EventToggles.tsx";
@@ -71,42 +71,30 @@ export default function Notification(props: Props) {
 
   return (
     <div className="app-root">
-      <header className={styles.toolbar}>
-        <span className={styles.mark}>
-          <Icon size={20}>notifications</Icon>
-        </span>
-        <div className={styles.titles}>
-          <h1 className={styles.title}>{t("notification.title")}</h1>
-          <p className={styles.subtitle}>{t("notification.subtitle")}</p>
-        </div>
-        <div className={styles.right}>
-          <button
-            type="button"
-            className={styles.epgLink}
-            onClick={props.onBack}
-            aria-label={t("notification.epg")}
-          >
-            <Icon size={18}>grid_view</Icon>
-          </button>
-          <button
-            type="button"
-            className={styles.epgLink}
-            onClick={props.onOpenWatch}
-            aria-label={t("watch.open")}
-          >
-            <Icon size={18}>live_tv</Icon>
-          </button>
-          <button
-            type="button"
-            className={styles.epgLink}
-            onClick={props.onBackToSettings}
-            aria-label={t("notification.settings")}
-          >
-            <Icon size={18}>settings</Icon>
-          </button>
-          <ColorSchemeToggle />
-        </div>
-      </header>
+      <PageHeader
+        icon="notifications"
+        title={t("notification.title")}
+        subtitle={t("notification.subtitle")}
+        links={[
+          {
+            icon: "grid_view",
+            label: t("notification.epg"),
+            onClick: props.onBack,
+          },
+          {
+            icon: "live_tv",
+            label: t("watch.open"),
+            onClick: props.onOpenWatch,
+          },
+          {
+            icon: "settings",
+            label: t("notification.settings"),
+            onClick: props.onBackToSettings,
+          },
+        ]}
+      >
+        <ColorSchemeToggle />
+      </PageHeader>
 
       <main className={styles.page}>
         <div className={styles.pageInner}>

--- a/client/components/templates/Program.stories.tsx
+++ b/client/components/templates/Program.stories.tsx
@@ -32,6 +32,7 @@ const meta = {
     onChangeChannelType: () => {},
     onSelectProgram: () => {},
     onOpenSearch: () => {},
+    onOpenWatch: () => {},
     onOpenSettings: () => {},
   },
 } satisfies Meta<typeof ProgramTemplate>;

--- a/client/components/templates/Program.test.tsx
+++ b/client/components/templates/Program.test.tsx
@@ -32,6 +32,7 @@ function setup(
       onChangeChannelType={() => {}}
       onSelectProgram={() => {}}
       onOpenSearch={() => {}}
+      onOpenWatch={() => {}}
       onOpenSettings={() => {}}
       {...overrides}
     />,

--- a/client/components/templates/Program.tsx
+++ b/client/components/templates/Program.tsx
@@ -47,6 +47,9 @@ type Props = {
   /** 設定ポータル (/settings) へ遷移する。 */
   onOpenSettings: () => void;
 
+  /** 視聴画面 (/watch) へ遷移する。 */
+  onOpenWatch: () => void;
+
   /** モーダル用のスロット (子ルートの Outlet を流し込む)。 */
   children?: ReactNode;
 };
@@ -78,6 +81,7 @@ export default function Program(props: Props) {
         channelType={channelType}
         onChangeChannelType={props.onChangeChannelType}
         onOpenSearch={props.onOpenSearch}
+        onOpenWatch={props.onOpenWatch}
         onOpenSettings={props.onOpenSettings}
       />
       {filteredServices.length === 0

--- a/client/components/templates/Settings.module.css
+++ b/client/components/templates/Settings.module.css
@@ -1,77 +1,3 @@
-/* templates/KeywordRules.module.css の .toolbar と同じ寸法・配色。 */
-.toolbar {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  gap: 1.2rem;
-  padding: 0 2rem;
-  height: 6rem;
-  background: var(--color-surface);
-  box-shadow: 0 1px 0 var(--color-border), var(--shadow-toolbar);
-  position: relative;
-  z-index: var(--z-index-toolbar);
-}
-
-.mark {
-  flex: 0 0 auto;
-  width: 3.6rem;
-  height: 3.6rem;
-  border-radius: 0.8rem;
-  background: color-mix(in srgb, var(--color-accent) 13%, transparent);
-  color: var(--color-accent);
-  display: grid;
-  place-items: center;
-}
-
-.titles {
-  display: flex;
-  flex-direction: column;
-  line-height: 1.2;
-  min-width: 0;
-}
-
-.title {
-  margin: 0;
-  font-weight: 700;
-  font-size: 1.5rem;
-  letter-spacing: 0.02rem;
-  white-space: nowrap;
-}
-
-.subtitle {
-  margin: 0;
-  font-size: 1.1rem;
-  color: var(--color-text-dim);
-  font-weight: 500;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.right {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-  gap: 1.2rem;
-}
-
-.epgLink {
-  display: grid;
-  place-items: center;
-  width: 3.6rem;
-  height: 3.6rem;
-  border-radius: 0.8rem;
-  border: 1px solid var(--color-border-strong);
-  background: var(--color-surface);
-  color: var(--color-text);
-  cursor: pointer;
-  transition: background 0.12s;
-
-  &:hover {
-    background: var(--color-surface-2);
-  }
-}
-
 /* ---- ページ本体 ---- */
 .page {
   flex: 1 1 auto;
@@ -180,15 +106,6 @@
 
 /* ---- mobile ---- */
 @container style(--is-mobile: true) {
-  .toolbar {
-    padding: 0 1.2rem;
-    gap: 0.8rem;
-  }
-
-  .subtitle {
-    display: none;
-  }
-
   .pageInner {
     padding: 2.4rem 1.2rem 8rem;
   }

--- a/client/components/templates/Settings.module.css
+++ b/client/components/templates/Settings.module.css
@@ -56,17 +56,14 @@
 }
 
 .epgLink {
-  display: flex;
-  align-items: center;
-  gap: 0.8rem;
-  padding: 0.8rem 1.2rem;
+  display: grid;
+  place-items: center;
+  width: 3.6rem;
+  height: 3.6rem;
   border-radius: 0.8rem;
   border: 1px solid var(--color-border-strong);
   background: var(--color-surface);
   color: var(--color-text);
-  font-family: inherit;
-  font-size: 1.3rem;
-  font-weight: 600;
   cursor: pointer;
   transition: background 0.12s;
 
@@ -189,10 +186,6 @@
   }
 
   .subtitle {
-    display: none;
-  }
-
-  .epgLinkText {
     display: none;
   }
 

--- a/client/components/templates/Settings.stories.tsx
+++ b/client/components/templates/Settings.stories.tsx
@@ -8,6 +8,7 @@ const meta = {
   args: {
     onOpenKeywords: () => {},
     onOpenNotification: () => {},
+    onOpenWatch: () => {},
     onBack: () => {},
   },
 } satisfies Meta<typeof Settings>;

--- a/client/components/templates/Settings.test.tsx
+++ b/client/components/templates/Settings.test.tsx
@@ -41,7 +41,7 @@ describe("Settings template", () => {
 
   it("番組表へ戻るリンクで onBack が発火する", () => {
     const { props } = setup();
-    fireEvent.click(screen.getByText(t("settings.epg")));
+    fireEvent.click(screen.getByLabelText(t("settings.epg")));
     expect(props.onBack).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/components/templates/Settings.test.tsx
+++ b/client/components/templates/Settings.test.tsx
@@ -7,6 +7,7 @@ function setup(override: Partial<Parameters<typeof Settings>[0]> = {}) {
   const props = {
     onOpenKeywords: vi.fn(),
     onOpenNotification: vi.fn(),
+    onOpenWatch: vi.fn(),
     onBack: vi.fn(),
     ...override,
   };
@@ -43,5 +44,11 @@ describe("Settings template", () => {
     const { props } = setup();
     fireEvent.click(screen.getByLabelText(t("settings.epg")));
     expect(props.onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("視聴画面へのリンクで onOpenWatch が発火する", () => {
+    const { props } = setup();
+    fireEvent.click(screen.getByLabelText(t("watch.open")));
+    expect(props.onOpenWatch).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/components/templates/Settings.tsx
+++ b/client/components/templates/Settings.tsx
@@ -34,9 +34,9 @@ export default function Settings(props: Props) {
             type="button"
             className={styles.epgLink}
             onClick={props.onBack}
+            aria-label={t("settings.epg")}
           >
-            <Icon size={15}>grid_view</Icon>
-            <span className={styles.epgLinkText}>{t("settings.epg")}</span>
+            <Icon size={18}>grid_view</Icon>
           </button>
           <ColorSchemeToggle />
         </div>

--- a/client/components/templates/Settings.tsx
+++ b/client/components/templates/Settings.tsx
@@ -1,4 +1,5 @@
 import Icon from "../atoms/Icon.tsx";
+import PageHeader from "../organisms/PageHeader.tsx";
 import ColorSchemeToggle from "../../islands/ColorSchemeToggle.tsx";
 import { t } from "../../locales/i18n.ts";
 import styles from "./Settings.module.css";
@@ -24,34 +25,25 @@ type Props = {
 export default function Settings(props: Props) {
   return (
     <div className="app-root">
-      <header className={styles.toolbar}>
-        <span className={styles.mark}>
-          <Icon size={20}>settings</Icon>
-        </span>
-        <div className={styles.titles}>
-          <h1 className={styles.title}>{t("settings.title")}</h1>
-          <p className={styles.subtitle}>{t("settings.subtitle")}</p>
-        </div>
-        <div className={styles.right}>
-          <button
-            type="button"
-            className={styles.epgLink}
-            onClick={props.onBack}
-            aria-label={t("settings.epg")}
-          >
-            <Icon size={18}>grid_view</Icon>
-          </button>
-          <button
-            type="button"
-            className={styles.epgLink}
-            onClick={props.onOpenWatch}
-            aria-label={t("watch.open")}
-          >
-            <Icon size={18}>live_tv</Icon>
-          </button>
-          <ColorSchemeToggle />
-        </div>
-      </header>
+      <PageHeader
+        icon="settings"
+        title={t("settings.title")}
+        subtitle={t("settings.subtitle")}
+        links={[
+          {
+            icon: "grid_view",
+            label: t("settings.epg"),
+            onClick: props.onBack,
+          },
+          {
+            icon: "live_tv",
+            label: t("watch.open"),
+            onClick: props.onOpenWatch,
+          },
+        ]}
+      >
+        <ColorSchemeToggle />
+      </PageHeader>
 
       <main className={styles.page}>
         <div className={styles.pageInner}>

--- a/client/components/templates/Settings.tsx
+++ b/client/components/templates/Settings.tsx
@@ -12,6 +12,9 @@ type Props = {
 
   /** 番組表へ戻る。 */
   onBack: () => void;
+
+  /** 視聴画面 (/watch) へ遷移する。 */
+  onOpenWatch: () => void;
 };
 
 /**
@@ -37,6 +40,14 @@ export default function Settings(props: Props) {
             aria-label={t("settings.epg")}
           >
             <Icon size={18}>grid_view</Icon>
+          </button>
+          <button
+            type="button"
+            className={styles.epgLink}
+            onClick={props.onOpenWatch}
+            aria-label={t("watch.open")}
+          >
+            <Icon size={18}>live_tv</Icon>
           </button>
           <ColorSchemeToggle />
         </div>

--- a/client/components/templates/Watch.module.css
+++ b/client/components/templates/Watch.module.css
@@ -1,80 +1,3 @@
-/* 設定画面 (templates/Settings.module.css 等) のツールバーと同じヘッダ骨格。
-   mark + titles + right で構成する。 */
-.toolbar {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  gap: 1.2rem;
-  padding: 0 2rem;
-  height: 6rem;
-  background: var(--color-surface);
-  box-shadow: 0 1px 0 var(--color-border), var(--shadow-toolbar);
-  position: relative;
-  z-index: var(--z-index-topbar);
-}
-
-.mark {
-  flex: 0 0 auto;
-  width: 3.6rem;
-  height: 3.6rem;
-  border-radius: 0.8rem;
-  background: color-mix(in srgb, var(--color-accent) 13%, transparent);
-  color: var(--color-accent);
-  display: grid;
-  place-items: center;
-}
-
-.titles {
-  display: flex;
-  flex-direction: column;
-  line-height: 1.2;
-  min-width: 0;
-}
-
-.headerTitle {
-  margin: 0;
-  font-weight: 700;
-  font-size: 1.5rem;
-  letter-spacing: 0.02rem;
-  white-space: nowrap;
-}
-
-.headerSubtitle {
-  margin: 0;
-  font-size: 1.1rem;
-  color: var(--color-text-dim);
-  font-weight: 500;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.right {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-  gap: 1.2rem;
-}
-
-/* 設定詳細ページのツールバーアイコン (.epgLink) と同じ見た目。 */
-.headerLink {
-  display: grid;
-  place-items: center;
-  width: 3.6rem;
-  height: 3.6rem;
-  border-radius: 0.8rem;
-  border: 1px solid var(--color-border-strong);
-  background: var(--color-surface);
-  color: var(--color-text);
-  text-decoration: none;
-  cursor: pointer;
-  transition: background 0.12s;
-
-  &:hover {
-    background: var(--color-surface-2);
-  }
-}
-
 .grid {
   flex: 1 1 auto;
   min-height: 0;
@@ -126,15 +49,6 @@
 
 /* ===== モバイル (コンテナクエリ) ===== */
 @container style(--is-mobile: true) {
-  .toolbar {
-    padding: 0 1.2rem;
-    gap: 0.8rem;
-  }
-
-  .headerSubtitle {
-    display: none;
-  }
-
   .grid {
     grid-template-columns: 1fr;
     grid-template-rows: auto 1fr;

--- a/client/components/templates/Watch.module.css
+++ b/client/components/templates/Watch.module.css
@@ -12,21 +12,19 @@
 }
 
 .backLink {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.8rem;
-  white-space: nowrap;
-  text-decoration: none;
-  color: var(--color-text);
-  font-weight: 600;
-  font-size: 1.6rem;
-  padding: 0.8rem 1.2rem 0.8rem 0.8rem;
+  display: grid;
+  place-items: center;
+  width: 3.6rem;
+  height: 3.6rem;
   border-radius: 0.8rem;
   border: 1px solid var(--color-border);
-  transition: background 0.12s;
+  color: var(--color-text-dim);
+  text-decoration: none;
+  transition: background 0.12s, color 0.12s;
 
   &:hover {
     background: var(--color-surface-2);
+    color: var(--color-text);
   }
 }
 

--- a/client/components/templates/Watch.module.css
+++ b/client/components/templates/Watch.module.css
@@ -1,44 +1,63 @@
-.topbar {
+/* 設定画面 (templates/Settings.module.css 等) のツールバーと同じヘッダ骨格。
+   mark + titles + right で構成する。 */
+.toolbar {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 1.6rem;
-  height: 5.6rem;
+  gap: 1.2rem;
   padding: 0 2rem;
+  height: 6rem;
   background: var(--color-surface);
-  box-shadow: 0 1px 0 var(--color-border), var(--shadow-panel);
+  box-shadow: 0 1px 0 var(--color-border), var(--shadow-toolbar);
+  position: relative;
   z-index: var(--z-index-topbar);
 }
 
-/* 設定詳細ページのツールバーアイコン (templates/*.module.css の .epgLink) と
-   同じ見た目に揃える。 */
-.backLink {
-  display: grid;
-  place-items: center;
+.mark {
+  flex: 0 0 auto;
   width: 3.6rem;
   height: 3.6rem;
   border-radius: 0.8rem;
-  border: 1px solid var(--color-border-strong);
-  background: var(--color-surface);
-  color: var(--color-text);
-  text-decoration: none;
-  transition: background 0.12s;
-
-  &:hover {
-    background: var(--color-surface-2);
-  }
+  background: color-mix(in srgb, var(--color-accent) 13%, transparent);
+  color: var(--color-accent);
+  display: grid;
+  place-items: center;
 }
 
-.topbarRight {
+.titles {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+  min-width: 0;
+}
+
+.headerTitle {
+  margin: 0;
+  font-weight: 700;
+  font-size: 1.5rem;
+  letter-spacing: 0.02rem;
+  white-space: nowrap;
+}
+
+.headerSubtitle {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--color-text-dim);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.right {
+  margin-left: auto;
   display: flex;
   align-items: center;
   gap: 1.2rem;
 }
 
-/* 設定ポータルへの正方形リンク。.backLink と同じく設定詳細ページの
-   ツールバーアイコン (.epgLink) と見た目を揃える。 */
-.settingsLink {
+/* 設定詳細ページのツールバーアイコン (.epgLink) と同じ見た目。 */
+.headerLink {
   display: grid;
   place-items: center;
   width: 3.6rem;
@@ -48,6 +67,7 @@
   background: var(--color-surface);
   color: var(--color-text);
   text-decoration: none;
+  cursor: pointer;
   transition: background 0.12s;
 
   &:hover {
@@ -106,9 +126,13 @@
 
 /* ===== モバイル (コンテナクエリ) ===== */
 @container style(--is-mobile: true) {
-  .topbar {
-    height: 5.2rem;
+  .toolbar {
     padding: 0 1.2rem;
+    gap: 0.8rem;
+  }
+
+  .headerSubtitle {
+    display: none;
   }
 
   .grid {

--- a/client/components/templates/Watch.module.css
+++ b/client/components/templates/Watch.module.css
@@ -11,20 +11,22 @@
   z-index: var(--z-index-topbar);
 }
 
+/* 設定詳細ページのツールバーアイコン (templates/*.module.css の .epgLink) と
+   同じ見た目に揃える。 */
 .backLink {
   display: grid;
   place-items: center;
   width: 3.6rem;
   height: 3.6rem;
   border-radius: 0.8rem;
-  border: 1px solid var(--color-border);
-  color: var(--color-text-dim);
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-surface);
+  color: var(--color-text);
   text-decoration: none;
-  transition: background 0.12s, color 0.12s;
+  transition: background 0.12s;
 
   &:hover {
     background: var(--color-surface-2);
-    color: var(--color-text);
   }
 }
 
@@ -34,22 +36,22 @@
   gap: 1.2rem;
 }
 
-/* atoms/IconButton と同じ見た目の正方形リンク (設定ポータルへ)。 */
+/* 設定ポータルへの正方形リンク。.backLink と同じく設定詳細ページの
+   ツールバーアイコン (.epgLink) と見た目を揃える。 */
 .settingsLink {
   display: grid;
   place-items: center;
   width: 3.6rem;
   height: 3.6rem;
   border-radius: 0.8rem;
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--color-border-strong);
   background: var(--color-surface);
-  color: var(--color-text-dim);
+  color: var(--color-text);
   text-decoration: none;
-  transition: background 0.12s, color 0.12s;
+  transition: background 0.12s;
 
   &:hover {
     background: var(--color-surface-2);
-    color: var(--color-text);
   }
 }
 

--- a/client/components/templates/Watch.stories.tsx
+++ b/client/components/templates/Watch.stories.tsx
@@ -50,6 +50,8 @@ const meta = {
   parameters: { layout: "fullscreen" },
   decorators: [withRouter],
   args: {
+    onBack: () => {},
+    onOpenSettings: () => {},
     streamUrl: undefined,
     audioTrackIndex: 0,
     onAudioTrackChange: () => {},

--- a/client/components/templates/Watch.test.tsx
+++ b/client/components/templates/Watch.test.tsx
@@ -46,6 +46,8 @@ function setup(
       comments={[]}
       liveConnected={false}
       onPostComment={() => {}}
+      onBack={() => {}}
+      onOpenSettings={() => {}}
       {...overrides}
     />,
   );
@@ -64,10 +66,11 @@ describe("Watch template", () => {
     ).toBeTruthy();
   });
 
-  it("設定ポータルへの歯車リンクを出す", async () => {
-    setup();
-    const link = await screen.findByLabelText(t("settings.open"));
-    expect(link.getAttribute("href")).toBe("/settings");
+  it("設定ポータルへの歯車ボタンで onOpenSettings が発火する", async () => {
+    const onOpenSettings = vi.fn();
+    setup({ onOpenSettings });
+    fireEvent.click(await screen.findByLabelText(t("settings.open")));
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
   });
 
   it("streamUrl 未指定なら Player は placeholder を出す (esm.sh を読まない)", async () => {

--- a/client/components/templates/Watch.test.tsx
+++ b/client/components/templates/Watch.test.tsx
@@ -55,7 +55,7 @@ function setup(
 describe("Watch template", () => {
   it("戻るリンクと右パネルのタブを描画する", async () => {
     setup();
-    expect(await screen.findByText(t("watch.back"))).toBeTruthy();
+    expect(await screen.findByLabelText(t("watch.back"))).toBeTruthy();
     expect(
       screen.getByRole("button", { name: t("watch.tab.select") }),
     ).toBeTruthy();

--- a/client/components/templates/Watch.tsx
+++ b/client/components/templates/Watch.tsx
@@ -67,17 +67,24 @@ export default function Watch(props: Props) {
 
   return (
     <div className="app-root">
-      <header className={styles.topbar}>
-        <Link
-          className={styles.backLink}
-          to="/program"
-          aria-label={t("watch.back")}
-        >
-          <Icon size={18}>grid_view</Icon>
-        </Link>
-        <div className={styles.topbarRight}>
+      <header className={styles.toolbar}>
+        <span className={styles.mark}>
+          <Icon size={20}>live_tv</Icon>
+        </span>
+        <div className={styles.titles}>
+          <h1 className={styles.headerTitle}>{t("watch.title")}</h1>
+          <p className={styles.headerSubtitle}>{t("watch.subtitle")}</p>
+        </div>
+        <div className={styles.right}>
           <Link
-            className={styles.settingsLink}
+            className={styles.headerLink}
+            to="/program"
+            aria-label={t("watch.back")}
+          >
+            <Icon size={18}>grid_view</Icon>
+          </Link>
+          <Link
+            className={styles.headerLink}
             to="/settings"
             aria-label={t("settings.open")}
           >

--- a/client/components/templates/Watch.tsx
+++ b/client/components/templates/Watch.tsx
@@ -68,9 +68,12 @@ export default function Watch(props: Props) {
   return (
     <div className="app-root">
       <header className={styles.topbar}>
-        <Link className={styles.backLink} to="/program">
-          <Icon size={18}>chevron_left</Icon>
-          <span>{t("watch.back")}</span>
+        <Link
+          className={styles.backLink}
+          to="/program"
+          aria-label={t("watch.back")}
+        >
+          <Icon size={18}>grid_view</Icon>
         </Link>
         <div className={styles.topbarRight}>
           <Link

--- a/client/components/templates/Watch.tsx
+++ b/client/components/templates/Watch.tsx
@@ -1,5 +1,4 @@
 import { type ComponentProps, useMemo } from "react";
-import { Link } from "@tanstack/react-router";
 import { formatHm, formatMd, formatWeekday } from "../../lib/datetime.ts";
 import { extractProgramMarks } from "../../lib/program-status.ts";
 import type { components } from "../../lib/api/schema.d.ts";
@@ -14,7 +13,7 @@ import InfoTab from "../organisms/Watch/InfoTab.tsx";
 import LiveCommentTab from "../organisms/Watch/LiveCommentTab.tsx";
 import ChannelBadge from "../atoms/ChannelBadge.tsx";
 import ProgramMarks from "../atoms/ProgramMarks.tsx";
-import Icon from "../atoms/Icon.tsx";
+import PageHeader from "../organisms/PageHeader.tsx";
 import ColorSchemeToggle from "../../islands/ColorSchemeToggle.tsx";
 import { t } from "../../locales/i18n.ts";
 import styles from "./Watch.module.css";
@@ -24,6 +23,13 @@ type Program = components["schemas"]["MirakurunProgram"];
 type PlayerProps = ComponentProps<typeof WatchPlayer>;
 
 type Props = {
+  // header
+  /** 番組表へ戻る。 */
+  onBack: () => void;
+
+  /** 設定ポータル (/settings) へ遷移する。 */
+  onOpenSettings: () => void;
+
   // player
   streamUrl: PlayerProps["streamUrl"];
   audioTrackIndex: PlayerProps["audioTrackIndex"];
@@ -67,32 +73,21 @@ export default function Watch(props: Props) {
 
   return (
     <div className="app-root">
-      <header className={styles.toolbar}>
-        <span className={styles.mark}>
-          <Icon size={20}>live_tv</Icon>
-        </span>
-        <div className={styles.titles}>
-          <h1 className={styles.headerTitle}>{t("watch.title")}</h1>
-          <p className={styles.headerSubtitle}>{t("watch.subtitle")}</p>
-        </div>
-        <div className={styles.right}>
-          <Link
-            className={styles.headerLink}
-            to="/program"
-            aria-label={t("watch.back")}
-          >
-            <Icon size={18}>grid_view</Icon>
-          </Link>
-          <Link
-            className={styles.headerLink}
-            to="/settings"
-            aria-label={t("settings.open")}
-          >
-            <Icon size={18}>settings</Icon>
-          </Link>
-          <ColorSchemeToggle />
-        </div>
-      </header>
+      <PageHeader
+        icon="live_tv"
+        title={t("watch.title")}
+        subtitle={t("watch.subtitle")}
+        links={[
+          { icon: "grid_view", label: t("watch.back"), onClick: props.onBack },
+          {
+            icon: "settings",
+            label: t("settings.open"),
+            onClick: props.onOpenSettings,
+          },
+        ]}
+      >
+        <ColorSchemeToggle />
+      </PageHeader>
 
       <div className={styles.grid}>
         <main className={styles.main}>

--- a/client/islands/Watch.tsx
+++ b/client/islands/Watch.tsx
@@ -29,6 +29,12 @@ type Props = {
   onAudioTrackChange: (index: number) => void;
   onQualityChange: (quality: Quality) => void;
   onCaptionToggle: () => void;
+
+  /** 番組表へ戻る。 */
+  onBack: () => void;
+
+  /** 設定ポータル (/settings) へ遷移する。 */
+  onOpenSettings: () => void;
 };
 
 /**
@@ -133,6 +139,8 @@ export default function Watch(props: Props) {
 
   return (
     <WatchTemplate
+      onBack={props.onBack}
+      onOpenSettings={props.onOpenSettings}
       streamUrl={streamUrl}
       audioTrackIndex={props.audioTrackIndex}
       onAudioTrackChange={props.onAudioTrackChange}

--- a/client/locales/ja-JP/keyword.ts
+++ b/client/locales/ja-JP/keyword.ts
@@ -3,6 +3,7 @@ export default {
   subtitle: "条件に一致する番組を自動で録画予約します",
   loading: "キーワードを読み込んでいます",
   toolbar: {
+    settings: "設定へ",
     epg: "番組表へ",
   },
   head: {

--- a/client/locales/ja-JP/keyword.ts
+++ b/client/locales/ja-JP/keyword.ts
@@ -1,6 +1,6 @@
 export default {
   title: "キーワード自動録画",
-  subtitle: "条件に一致する番組を自動で録画予約します",
+  subtitle: "条件に一致する番組を自動で録画予約します。",
   loading: "キーワードを読み込んでいます",
   toolbar: {
     settings: "設定へ",

--- a/client/locales/ja-JP/notification.ts
+++ b/client/locales/ja-JP/notification.ts
@@ -1,6 +1,6 @@
 export default {
   title: "通知設定",
-  subtitle: "録画イベントを ntfy.sh で通知します",
+  subtitle: "録画イベントを ntfy.sh で通知します。",
   lead:
     "録画の開始・終了を ntfy.sh のトピックへ送信します。スマートフォンの ntfy アプリで同じトピックを購読すると、プッシュ通知として受け取れます。",
   loading: "通知設定を読み込んでいます",

--- a/client/locales/ja-JP/notification.ts
+++ b/client/locales/ja-JP/notification.ts
@@ -4,6 +4,7 @@ export default {
   lead:
     "録画の開始・終了を ntfy.sh のトピックへ送信します。スマートフォンの ntfy アプリで同じトピックを購読すると、プッシュ通知として受け取れます。",
   loading: "通知設定を読み込んでいます",
+  settings: "設定へ",
   epg: "番組表へ",
   server: {
     title: "ntfy.sh サーバー",

--- a/client/locales/ja-JP/settings.ts
+++ b/client/locales/ja-JP/settings.ts
@@ -1,6 +1,6 @@
 export default {
   title: "設定",
-  subtitle: "録画・通知の設定をまとめて管理",
+  subtitle: "録画・通知の設定をまとめて管理。",
   lead: "録画と通知に関する設定画面の一覧です。",
   open: "設定を開く",
   epg: "番組表へ",

--- a/client/locales/ja-JP/watch.ts
+++ b/client/locales/ja-JP/watch.ts
@@ -1,5 +1,7 @@
 export default {
   title: "視聴",
+  subtitle: "選局して番組をライブ視聴します。",
+  open: "視聴画面を開く",
   watch: "視聴する",
   loading: "プレイヤーを準備しています",
   selectService: "チャンネルを選択してください",

--- a/client/routes/program/$channelType.tsx
+++ b/client/routes/program/$channelType.tsx
@@ -117,6 +117,11 @@ function ProgramLayout() {
     navigate({ to: "/settings" });
   };
 
+  // 視聴画面へ。
+  const handleOpenWatch = () => {
+    navigate({ to: "/watch" });
+  };
+
   if (services.isPending || programs.isPending) {
     return <LoadingTemplate label={t("program.loading")} />;
   }
@@ -133,6 +138,7 @@ function ProgramLayout() {
       onChangeChannelType={handleChangeChannelType}
       onSelectProgram={handleSelectProgram}
       onOpenSearch={handleOpenSearch}
+      onOpenWatch={handleOpenWatch}
       onOpenSettings={handleOpenSettings}
     >
       <Outlet />

--- a/client/routes/settings/index.tsx
+++ b/client/routes/settings/index.tsx
@@ -19,6 +19,7 @@ function SettingsPage() {
     <SettingsTemplate
       onOpenKeywords={() => navigate({ to: "/settings/keywords" })}
       onOpenNotification={() => navigate({ to: "/settings/notification" })}
+      onOpenWatch={() => navigate({ to: "/watch" })}
       onBack={() => navigate({ to: "/" })}
     />
   );

--- a/client/routes/settings/keywords.tsx
+++ b/client/routes/settings/keywords.tsx
@@ -80,6 +80,7 @@ function KeywordRulesPage() {
         })}
       onToggle={(rule) => toggle.mutate(rule)}
       onRemove={(rule) => remove.mutate(rule)}
+      onBackToSettings={() => navigate({ to: "/settings" })}
       onBack={() => navigate({ to: "/" })}
     >
       <Outlet />

--- a/client/routes/settings/keywords.tsx
+++ b/client/routes/settings/keywords.tsx
@@ -81,6 +81,7 @@ function KeywordRulesPage() {
       onToggle={(rule) => toggle.mutate(rule)}
       onRemove={(rule) => remove.mutate(rule)}
       onBackToSettings={() => navigate({ to: "/settings" })}
+      onOpenWatch={() => navigate({ to: "/watch" })}
       onBack={() => navigate({ to: "/" })}
     >
       <Outlet />

--- a/client/routes/settings/notification.tsx
+++ b/client/routes/settings/notification.tsx
@@ -60,6 +60,7 @@ function NotificationSettingsPage() {
       onTest={async (target) => {
         await test.mutateAsync(target);
       }}
+      onBackToSettings={() => navigate({ to: "/settings" })}
       onBack={() => navigate({ to: "/" })}
     />
   );

--- a/client/routes/settings/notification.tsx
+++ b/client/routes/settings/notification.tsx
@@ -61,6 +61,7 @@ function NotificationSettingsPage() {
         await test.mutateAsync(target);
       }}
       onBackToSettings={() => navigate({ to: "/settings" })}
+      onOpenWatch={() => navigate({ to: "/watch" })}
       onBack={() => navigate({ to: "/" })}
     />
   );

--- a/client/routes/watch/$serviceId.tsx
+++ b/client/routes/watch/$serviceId.tsx
@@ -38,6 +38,8 @@ function WatchServicePage() {
   return (
     <Watch
       serviceId={sid}
+      onBack={() => navigate({ to: "/program" })}
+      onOpenSettings={() => navigate({ to: "/settings" })}
       audioTrackIndex={audioTrack}
       quality={quality}
       captionVisible={caption}

--- a/client/routes/watch/index.tsx
+++ b/client/routes/watch/index.tsx
@@ -19,6 +19,8 @@ function WatchIndexPage() {
   // サービス未選択の状態。サービスリストから選ぶと /watch/$serviceId へ遷移する。
   return (
     <Watch
+      onBack={() => navigate({ to: "/program" })}
+      onOpenSettings={() => navigate({ to: "/settings" })}
       audioTrackIndex={0}
       quality={defaultQuality}
       captionVisible

--- a/deno.lock
+++ b/deno.lock
@@ -1,6 +1,7 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@aireone/deno-lint-curly@*": "0.2.0",
     "jsr:@std/assert@1.0.19": "1.0.19",
     "jsr:@std/datetime@0.225.7": "0.225.7",
     "jsr:@std/internal@^1.0.12": "1.0.14",
@@ -33,6 +34,9 @@
     "npm:vitest@4.1.8": "4.1.8_@vitest+coverage-v8@4.1.8_happy-dom@20.10.3_vite@8.0.16"
   },
   "jsr": {
+    "@aireone/deno-lint-curly@0.2.0": {
+      "integrity": "c182ea5d2ed999c06ffa88a21aac2aed3cf0d14a1128d7fad3034337f7822b48"
+    },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [


### PR DESCRIPTION
## 概要

設定系ページと視聴画面のヘッダ / ナビゲーション導線を全画面で統一した。当初は「設定子ページから設定ポータルへ戻る導線の追加」だったが、ヘッダ全体のナビゲーション統一まで広げた。

最終的に、全画面のヘッダ右側が `[番組表] [視聴] [設定] [テーマ]` の同じ並びに収束し、どの画面からでも主要画面へ 1 クリックで移動できるグローバルナビになっている（各画面は自身に当たるリンクを省く）。

## 変更点

### 1. 設定子ページに設定ポータルへの戻り導線を追加
- 通知設定 (`/settings/notification`) とキーワード自動録画 (`/settings/keywords`) のツールバーに設定ポータル (`/settings`) へ戻る導線を追加。
- これまで設定子ページから親ポータルへ戻るには一度番組表まで戻る必要があった。

### 2. ツールバーの戻りリンクをアイコンのみに統一
- 「番組表へ」「設定へ」の文言ラベルを廃し、アイコンのみのボタン / リンクに統一（設定ポータル `/settings` も含む）。
- 設定へ戻るアイコンを歯車 (`settings`) に変更。
- 視聴画面の番組表リンクを `chevron_left` から `grid_view` に変更し、設定系のアイコンと統一。
- アイコンのみのボタン / リンクに `aria-label` を付与し、テストを `getByText` → `getByLabelText` に追従。

### 3. 視聴画面ヘッダを設定画面風に再設計
- 左寄せの戻りリンク構成から、設定画面と同じ `mark(live_tv) + タイトル / サブタイトル + 右リンク群` の骨格に再設計。
- `watch.subtitle`（「選局して番組をライブ視聴します。」）/ `watch.open`（「視聴画面を開く」）を locales に追加。

### 4. 全画面に視聴画面へのリンクを追加
- 番組表 (`Program/Toolbar`)・設定ポータル・設定詳細の各ヘッダに視聴画面 (`/watch`) への `live_tv` リンクを追加。
- 各テンプレに `onOpenWatch` props を追加し、route で `/watch` へ配線。

### 5. その他
- 設定系ページの subtitle 末尾に句点を統一。
- `origin/main`（#41〜#44 マージ済み）を追従。#44（設定画面の TanStack Form 化）とはコンフリクトなく統合。

## 確認

- `deno task check` / `deno task lint`（fmt 含む）パス
- client テスト全体 245 件パス
- ヘッダの見た目変更を含むため、各画面のヘッダ並び・視聴画面の新ヘッダはブラウザ目視を推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)