### PR TITLE
fix: モバイル視聴画面でプレイヤー部とタブ部の余白が無いのを修正

### DIFF
--- a/client/components/templates/Watch.module.css
+++ b/client/components/templates/Watch.module.css
@@ -114,7 +114,7 @@
   .grid {
     grid-template-columns: 1fr;
     grid-template-rows: auto 1fr;
-    gap: 0;
+    gap: 1.2rem;
     padding: 0;
     overflow: visible;
   }


### PR DESCRIPTION
## 概要

モバイル幅で番組視聴ページ (`/watch/$serviceId`) を表示すると、プレイヤー（および番組情報）とタブパネルが密着して余白が無かったのを修正した。

## 原因

モバイル (`@container style(--is-mobile: true)`) では `.grid` が縦積み (`grid-template-rows: auto 1fr`) になるが、`gap: 0` のため上段（`.main`: プレイヤー + 番組情報）と下段（`TabPanel`）の間に余白が出ていなかった。`.main` の padding-bottom も 0 で境界がゼロだった。

## 変更点

- `Watch.module.css` のモバイル指定で `.grid` の `gap` を `0` → `1.2rem` に変更。1 列レイアウトなので実質 row-gap として効き、上下段の境界にのみ余白が入る。デスクトップ側の `gap: 2rem` は別ルールで影響なし。

## 確認

- `deno task check` / `deno task lint` (fmt 含む) パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)