### PR TITLE
fix: プレイヤーにフォーカスがあると UI が出続けるのを修正

### DIFF
--- a/client/components/organisms/Watch/Player.module.css
+++ b/client/components/organisms/Watch/Player.module.css
@@ -61,7 +61,11 @@
   }
 }
 
-.player:focus-within .controls {
+/* コントロール内のボタンにフォーカスがあるときだけ表示する (キーボード操作)。
+   プレイヤー枠 (tabIndex=0) 自体への focus では出さない。全画面化すると枠に
+   フォーカスが入るため、.player:focus-within だとカーソルが隠れても UI だけ
+   残り続けてしまう。 */
+.controls:focus-within {
   opacity: 1;
 }
 


### PR DESCRIPTION
## 概要

プレイヤーにフォーカスがあるとコントロール UI が表示されたままになり、特に全画面表示で UI が消えなくなる問題を修正した。

## 原因

プレイヤー枠 (`.player`) は `tabIndex={0}` でフォーカス可能。全画面化すると枠自体にフォーカスが入り、`.player:focus-within .controls { opacity: 1 }` が常時真になってコントロールが消えなくなっていた。カーソルは `.player:fullscreen:not(.controlsVisible)` で隠れるのに、UI だけ残る状態だった。

## 変更点

- `Player.module.css` の表示条件を `.player:focus-within .controls` → `.controls:focus-within` に変更。コントロール内のボタンにフォーカスがあるとき（キーボードで Tab 移動した場合）だけ表示する。プレイヤー枠自体への focus では出さない。
- これにより全画面アイドル時は、カーソルが非表示になるタイミング（`controlsVisible` が false）と同じタイミングで UI も非表示になる。ホバー表示・タップ表示・`controlsVisible` 連動は従来どおり。

## 確認

- `deno task check` / `deno task lint` (fmt 含む) パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)