### PR TITLE
fix: 受信中/エラーのすりガラスを除去し全画面から戻れるようにする

### DIFF
--- a/client/assets/styles/palette.css
+++ b/client/assets/styles/palette.css
@@ -393,11 +393,13 @@
   /* -- モーダル内 (dialog は top layer のため overlay 自体は z-index 不要) -- */
   --z-index-modal-close: 5; /* 閉じボタン */
 
-  /* -- プレイヤー内 (.player の独立コンテキスト: 映像 -> 字幕 -> UI -> 状態) -- */
+  /* -- プレイヤー内 (.player の独立コンテキスト: 映像 -> 字幕 -> 状態 -> UI) --
+     コントロールを受信中 / エラーのオーバーレイより前面に置く。全画面中に
+     受信中 / エラーになっても全画面解除ボタンを操作できるようにするため。 */
   --z-index-player-stage: 0; /* ジャンルグラデ背景 (映像背面) */
   --z-index-player-video: 1; /* video 要素 */
   --z-index-player-caption: 2; /* 字幕 canvas オーバーレイ */
-  --z-index-player-controls: 5; /* コントロール */
-  --z-index-player-buffering: 6; /* 受信中オーバーレイ */
-  --z-index-player-error: 7; /* 再生エラーオーバーレイ */
+  --z-index-player-buffering: 3; /* 受信中オーバーレイ */
+  --z-index-player-error: 4; /* 再生エラーオーバーレイ */
+  --z-index-player-controls: 5; /* コントロール (受信中 / エラーより前面) */
 }

--- a/client/components/organisms/Watch/Player.module.css
+++ b/client/components/organisms/Watch/Player.module.css
@@ -207,9 +207,10 @@
   z-index: var(--z-index-player-buffering);
   display: grid;
   place-items: center;
+  /* 操作要素を持たないオーバーレイ。前面のコントロール (全画面解除等) を
+     クリックできるよう pointer を透過する。 */
+  pointer-events: none;
   background: rgba(5, 7, 11, 0.74);
-  -webkit-backdrop-filter: blur(3px);
-  backdrop-filter: blur(3px);
   animation: overlayFadeIn 0.2s ease;
 }
 
@@ -290,8 +291,6 @@
   padding: 2.4rem;
   text-align: center;
   background: rgba(5, 7, 11, 0.86);
-  -webkit-backdrop-filter: blur(4px);
-  backdrop-filter: blur(4px);
   animation: overlayFadeIn 0.22s ease;
 }
 


### PR DESCRIPTION
## 概要

プレイヤーの受信中（チューニング/バッファリング）・再生エラーのオーバーレイについて、2点を修正した。

1. **すりガラス除去**: `backdrop-filter: blur()` で背景のジャンルグラデーションがぼやけていたのを除去。
2. **全画面から戻れない問題**: 全面オーバーレイがコントロールの上に重なり、全画面中に受信中/エラーになると全画面解除ボタンを押せなかったのを修正。

## 原因

- `.buffering` / `.playerError` に `backdrop-filter: blur(3px/4px)` が掛かっており、背面のグラデーション (`stage`) がぼやけていた。
- プレイヤー内の z-index が `controls:5 < buffering:6 < error:7`。両オーバーレイは `inset: 0` で全面を覆うため、コントロール（全画面解除ボタンを含む）の上に被さって操作できなかった。

## 変更点

- `Player.module.css`: `.buffering` / `.playerError` から `backdrop-filter` / `-webkit-backdrop-filter`（blur）を削除。半透明の暗幕（`rgba(...)`）はスピナー・エラー文の視認性のため残す。
- `Player.module.css`: `.buffering` に `pointer-events: none` を追加（操作要素ゼロのため、前面のコントロールへクリックを透過）。
- `palette.css`: プレイヤー内 z-index を `映像 → 字幕 → 状態 → UI` の順に並べ替え（`buffering:3 / error:4 / controls:5`）。コントロールを最前面にして、受信中/エラー時も全画面解除を操作可能にした。
  - 再試行ボタン（エラー中央）とコントロール（下端）は位置が重ならないため、両方操作できる。
  - プレイヤーは独立スタッキングコンテキストで、番組表など他グループの z-index には影響しない。

## 確認

- `deno task check` / `deno task lint` (fmt 含む) パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)