### PR TITLE
build: tsreadex を ARG 化して最新へ、devcontainer の Deno を整合

### DIFF
--- a/.claude/rules/docker.md
+++ b/.claude/rules/docker.md
@@ -5,7 +5,7 @@
 ## ステージ構成
 
 1. `mirakc-ui-build` — Deno イメージで `deno install` + `deno task build` を実行し `client/dist`（Vite ビルド成果物）を生成。
-2. `tsreadex-build` — Debian bookworm-slim。[tsreadex](https://github.com/xtne6f/tsreadex)（`master-240517`）をソースビルドしてバイナリ化。
+2. `tsreadex-build` — Debian bookworm-slim。[tsreadex](https://github.com/xtne6f/tsreadex) をソースビルドしてバイナリ化。バージョンは `Dockerfile` の `ARG TSREADEX_VERSION`（既定 `master-260428`）で指定し、`--build-arg TSREADEX_VERSION=<tag>` で上書きできる。
 3. 最終ステージ — Deno イメージに `ffmpeg` を apt で追加し、`tsreadex` バイナリ・`client/dist`・`server/` をコピー。`deno serve server/main.ts`（Hono）で起動し、`client/dist` を `serveStatic` で配信しつつ `/api`（mirakc プロキシ / transcode）を提供する。`server/routes/transcode.ts` から `ffmpeg` / `tsreadex` を spawn する。
 
 > 旧構成は Fresh の `_fresh/server.js` を `deno serve` していた。本番起動は Hono の `server/main.ts` に置き換わった。

--- a/.devcontainer/onCreateCommand.sh
+++ b/.devcontainer/onCreateCommand.sh
@@ -4,7 +4,7 @@ set -o nounset
 set -o xtrace
 
 # Install Deno
-curl -fsSL https://deno.land/install.sh | sudo DENO_INSTALL=/usr/local sh -s -- -y "v2.8.1"
+curl -fsSL https://deno.land/install.sh | sudo DENO_INSTALL=/usr/local sh -s -- -y "v2.8.3"
 
 # Install Claude Code
 #curl -fsSL https://claude.ai/install.sh | bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM docker.io/denoland/deno:2.8.2 AS mirakc-ui-build
+FROM --platform=$BUILDPLATFORM docker.io/denoland/deno:2.8.3 AS mirakc-ui-build
 
 WORKDIR /app
 
@@ -8,6 +8,10 @@ RUN deno task build
 
 FROM docker.io/debian:bookworm-slim AS tsreadex-build
 
+# tsreadex のバージョン (xtne6f/tsreadex のタグ)。
+# 上書き例: docker build --build-arg TSREADEX_VERSION=master-240517 ...
+ARG TSREADEX_VERSION=master-260428
+
 RUN <<EOF
     apt-get update
     apt-get install -y --no-install-recommends g++ cmake make curl ca-certificates
@@ -15,14 +19,14 @@ RUN <<EOF
 EOF
 
 RUN <<EOF
-    curl -fsSL https://github.com/xtne6f/tsreadex/archive/refs/tags/master-240517.tar.gz \
+    curl -fsSL https://github.com/xtne6f/tsreadex/archive/refs/tags/${TSREADEX_VERSION}.tar.gz \
         | tar -xz -C /tmp
-    mv /tmp/tsreadex-master-240517 /tmp/tsreadex
+    mv /tmp/tsreadex-${TSREADEX_VERSION} /tmp/tsreadex
     cmake -B /tmp/tsreadex/build -S /tmp/tsreadex -DCMAKE_BUILD_TYPE=Release
     cmake --build /tmp/tsreadex/build
 EOF
 
-FROM docker.io/denoland/deno:2.8.2
+FROM docker.io/denoland/deno:2.8.3
 
 ARG GIT_REVISION
 ENV DENO_DEPLOYMENT_ID=${GIT_REVISION}

--- a/deno.lock
+++ b/deno.lock
@@ -1,6 +1,7 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@aireone/deno-lint-curly@*": "0.2.0",
     "jsr:@std/assert@1.0.19": "1.0.19",
     "jsr:@std/datetime@0.225.7": "0.225.7",
     "jsr:@std/internal@^1.0.12": "1.0.14",
@@ -33,6 +34,9 @@
     "npm:vitest@4.1.8": "4.1.8_@vitest+coverage-v8@4.1.8_happy-dom@20.10.3_vite@8.0.16"
   },
   "jsr": {
+    "@aireone/deno-lint-curly@0.2.0": {
+      "integrity": "c182ea5d2ed999c06ffa88a21aac2aed3cf0d14a1128d7fad3034337f7822b48"
+    },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [


### PR DESCRIPTION
## 概要

本番 Docker ビルドまわりのアップグレード。Dockerfile の tsreadex を `ARG` 化して最新タグへ、取り残されていた devcontainer の Deno を Dockerfile と整合させた。あわせて依存の最新化を確認し、`deno.lock` を補完した。

> **Note:** これは #44 の上に積んだ stacked PR です（base = `feature/tanstack-form-settings`）。`deno.json`/`deno.lock` を共有するため #44 と土台を分けられません。**#44 をマージしたら本 PR の base を `main` に戻してください**（GitHub が自動で切り替える場合もあります）。

## 変更点

- **`Dockerfile`** — `tsreadex-build` ステージに `ARG TSREADEX_VERSION=master-260428` を追加し、tar アーカイブ URL とリネーム先ディレクトリの2箇所を `${TSREADEX_VERSION}` 参照に統一。tsreadex を `master-240517`（2024-05）→ `master-260428`（2026-04）へ更新しつつ `--build-arg TSREADEX_VERSION=<tag>` で上書き可能にした。
- **`.devcontainer/onCreateCommand.sh`** — Deno を `v2.8.1` → `v2.8.3` にし、`Dockerfile`（`deno:2.8.3`）と整合（deno.md ルール）。
- **`.claude/rules/docker.md`** — tsreadex のバージョン記述を ARG 方式に追従。
- **`deno.lock`** — `deno outdated --latest --update` を実行。依存はすべて最新で upgrade 対象なし（storybook / @storybook/react-vite / aribb24.js / happy-dom は #44 で最新化済み）。`deno task lint` が使う `jsr:@aireone/deno-lint-curly` の解決が lock に補完された分を反映した。

build ツール（vite / @vitejs/plugin-react / @deno/vite-plugin / vite-plugin-svgr / @tanstack/router-plugin）と CI の GitHub Actions も既に最新のため変更なし。

## 検証

- `docker build --target tsreadex-build`（既定）/ `--build-arg TSREADEX_VERSION=master-240517` ともにビルド成功 — `master-260428` のコンパイルと ARG パラメータ化を確認。
- `deno task check` / `lint` / `test`（server + client）/ `build` / `storybook:build` すべて緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
