### PR TITLE
feat: キーワードルールの型・検証を JSON Schema 単一ソース化する

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -32,6 +32,8 @@
   },
   "imports": {
     "@/": "./",
+    "@cfworker/json-schema": "npm:@cfworker/json-schema@4.1.1",
+    "json-schema-to-ts": "npm:json-schema-to-ts@3.1.1",
     "react": "npm:react@19.2.7",
     "react/jsx-runtime": "npm:react@19.2.7/jsx-runtime",
     "react/jsx-dev-runtime": "npm:react@19.2.7/jsx-dev-runtime",

--- a/deno.lock
+++ b/deno.lock
@@ -5,6 +5,7 @@
     "jsr:@std/assert@1.0.19": "1.0.19",
     "jsr:@std/datetime@0.225.7": "0.225.7",
     "jsr:@std/internal@^1.0.12": "1.0.14",
+    "npm:@cfworker/json-schema@4.1.1": "4.1.1",
     "npm:@deno/vite-plugin@2.0.2": "2.0.2_vite@8.0.16",
     "npm:@storybook/react-vite@10.4.4": "10.4.4_react@19.2.7_react-dom@19.2.7__react@19.2.7_storybook@10.4.4__@types+react@19.2.17__@testing-library+dom@10.4.1__react@19.2.7__react-dom@19.2.7___react@19.2.7_vite@8.0.16_@testing-library+dom@10.4.1_@types+react@19.2.17_@types+react-dom@19.2.3__@types+react@19.2.17_typescript@6.0.3",
     "npm:@tanstack/react-form@1.33.0": "1.33.0_react@19.2.7_react-dom@19.2.7__react@19.2.7",
@@ -22,6 +23,7 @@
     "npm:happy-dom@20.10.3": "20.10.3",
     "npm:hono@4.12.25": "4.12.25",
     "npm:i18next@26.3.1": "26.3.1_typescript@6.0.3",
+    "npm:json-schema-to-ts@3.1.1": "3.1.1",
     "npm:openapi-fetch@0.17.0": "0.17.0",
     "npm:openapi-react-query@0.5.4": "0.5.4_@tanstack+react-query@5.101.0__react@19.2.7_openapi-fetch@0.17.0_react@19.2.7",
     "npm:openapi-typescript-helpers@0.1.0": "0.1.0",
@@ -179,6 +181,9 @@
     },
     "@bcoe/v8-coverage@1.0.2": {
       "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="
+    },
+    "@cfworker/json-schema@4.1.1": {
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og=="
     },
     "@deno/vite-plugin@2.0.2_vite@8.0.16": {
       "integrity": "sha512-bzuKApn9Jr2x1jSrbuJEJzy++8LUwjFVOAopAbepcE3RgYzdcPEWd36PSp7P5dNMQlNnQlgtm3MeNbcKZ/Eh/Q==",
@@ -429,8 +434,6 @@
     "@napi-rs/wasm-runtime@1.1.5_@emnapi+core@1.9.2_@emnapi+runtime@1.9.2": {
       "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dependencies": [
-        "@emnapi/core@1.9.2",
-        "@emnapi/runtime@1.9.2",
         "@tybys/wasm-util"
       ]
     },
@@ -1792,6 +1795,13 @@
     "json-parse-even-better-errors@2.3.1": {
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
+    "json-schema-to-ts@3.1.1": {
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dependencies": [
+        "@babel/runtime",
+        "ts-algebra"
+      ]
+    },
     "json-schema-traverse@1.0.0": {
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
@@ -2338,6 +2348,9 @@
     "tinyspy@4.0.4": {
       "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="
     },
+    "ts-algebra@2.0.0": {
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="
+    },
     "ts-dedent@2.3.0": {
       "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg=="
     },
@@ -2496,6 +2509,7 @@
     "dependencies": [
       "jsr:@std/assert@1.0.19",
       "jsr:@std/datetime@0.225.7",
+      "npm:@cfworker/json-schema@4.1.1",
       "npm:@deno/vite-plugin@2.0.2",
       "npm:@storybook/react-vite@10.4.4",
       "npm:@tanstack/react-form@1.33.0",
@@ -2513,6 +2527,7 @@
       "npm:happy-dom@20.10.3",
       "npm:hono@4.12.25",
       "npm:i18next@26.3.1",
+      "npm:json-schema-to-ts@3.1.1",
       "npm:openapi-fetch@0.17.0",
       "npm:openapi-react-query@0.5.4",
       "npm:openapi-typescript-helpers@0.1.0",

--- a/server/lib/keyword-rules.test.ts
+++ b/server/lib/keyword-rules.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "@std/assert";
 import {
+  isKeywordRule,
   type KeywordRule,
   matchesKeywordRule,
   parseKeywordRuleInput,
@@ -166,4 +167,44 @@ Deno.test("parseKeywordRuleInput: 不正値は ok:false", () => {
     to: "2026-01-01",
   });
   assertEquals(sameDay.ok, true);
+});
+
+Deno.test("isKeywordRule: 正当な保存値を受け入れる", () => {
+  assertEquals(isKeywordRule(rule()), true);
+  assertEquals(
+    isKeywordRule(rule({ from: "2026-01-01", to: "2026-01-31" })),
+    true,
+  );
+  // 期間未指定は from / to が undefined キーで保存される (KV / V8 直列化は
+  // undefined を保持する)。検証前に均すため drop されないこと。
+  assertEquals(
+    isKeywordRule({ ...rule(), from: undefined, to: undefined }),
+    true,
+  );
+  // 未知キーがあっても寛容に受け入れる (旧 isKeywordRule と同じ挙動)。
+  assertEquals(isKeywordRule({ ...rule(), legacyField: 1 }), true);
+});
+
+Deno.test("isKeywordRule: 壊れた値は除外する", () => {
+  const broken: unknown[] = [
+    null,
+    undefined,
+    "rule",
+    123,
+    {},
+    // 必須キー欠落。
+    { keyword: "x", serviceIds: [], genres: [], enabled: true },
+    // 型違い。
+    { ...rule(), createdAt: "x" },
+    { ...rule(), enabled: "yes" },
+    { ...rule(), keyword: "" },
+    // 範囲外ジャンル。
+    { ...rule(), genres: [16] },
+    { ...rule(), genres: [-1] },
+    // 日付書式違反。
+    { ...rule(), from: "2026/01/01" },
+  ];
+  for (const value of broken) {
+    assertEquals(isKeywordRule(value), false, JSON.stringify(value));
+  }
 });

--- a/server/lib/keyword-rules.ts
+++ b/server/lib/keyword-rules.ts
@@ -5,34 +5,67 @@
  * client (一致プレビュー・件数表示) の両方から runtime import される
  * (server/lib/quality.ts と同じ共有パターン)。永続化は
  * server/store/keyword-rules.ts (Deno KV) が担う。
+ *
+ * 型・構造検証の単一ソースは JSON Schema (keywordRuleSchema)。静的型は
+ * json-schema-to-ts の FromSchema で導出し、実行時検証は @cfworker/json-schema
+ * で行う。バリデータは遅延構築する — client は matchesKeywordRule だけを
+ * runtime import するため、最上位でバリデータを構築すると @cfworker が client
+ * バンドルに混入する。遅延構築なら未使用時に tree-shake で除去される。
  */
 
-/** キーワード自動録画のルール。 */
-export type KeywordRule = {
-  /** ルールの識別子 (UUID)。 */
-  id: string;
+import type { FromSchema } from "json-schema-to-ts";
+import { Validator } from "@cfworker/json-schema";
 
-  /** 番組名に対して部分一致させるキーワード (大文字小文字無視)。 */
-  keyword: string;
+const DATE_PATTERN = "^\\d{4}-\\d{2}-\\d{2}$";
 
-  /** 期間の開始日 (ローカル日付 YYYY-MM-DD、両端含む)。未指定は無制限。 */
-  from?: string;
+/**
+ * キーワード自動録画ルールの JSON Schema (型・構造検証の単一ソース)。
+ * 型・範囲・日付書式はここに集約する。フィールド間の条件 (from <= to) は
+ * JSON Schema で表現できないため parseKeywordRuleInput で別途検証する。
+ */
+export const keywordRuleSchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    id: { type: "string", description: "ルールの識別子 (UUID)" },
+    keyword: {
+      type: "string",
+      minLength: 1,
+      description: "番組名に対して部分一致させるキーワード (大文字小文字無視)",
+    },
+    from: {
+      type: "string",
+      pattern: DATE_PATTERN,
+      description:
+        "期間の開始日 (ローカル日付 YYYY-MM-DD、両端含む)。未指定は無制限",
+    },
+    to: {
+      type: "string",
+      pattern: DATE_PATTERN,
+      description:
+        "期間の終了日 (ローカル日付 YYYY-MM-DD、両端含む)。未指定は無制限",
+    },
+    serviceIds: {
+      type: "array",
+      items: { type: "integer" },
+      description: "対象サービス (Mirakurun service id)。空配列は全チャンネル",
+    },
+    genres: {
+      type: "array",
+      items: { type: "integer", minimum: 0, maximum: 15 },
+      description: "対象ジャンル (ARIB lv1 コード 0..15)。空配列は全ジャンル",
+    },
+    enabled: {
+      type: "boolean",
+      description: "有効/停止。停止中は自動予約しない",
+    },
+    createdAt: { type: "number", description: "登録日時 (epoch ms)" },
+  },
+  required: ["id", "keyword", "serviceIds", "genres", "enabled", "createdAt"],
+} as const;
 
-  /** 期間の終了日 (ローカル日付 YYYY-MM-DD、両端含む)。未指定は無制限。 */
-  to?: string;
-
-  /** 対象サービス (Mirakurun service id)。空配列は全チャンネル。 */
-  serviceIds: number[];
-
-  /** 対象ジャンル (ARIB lv1 コード 0..15)。空配列は全ジャンル。 */
-  genres: number[];
-
-  /** 有効/停止。停止中は自動予約しない。 */
-  enabled: boolean;
-
-  /** 登録日時 (epoch ms)。 */
-  createdAt: number;
-};
+/** キーワード自動録画のルール (keywordRuleSchema から導出)。 */
+export type KeywordRule = FromSchema<typeof keywordRuleSchema>;
 
 /** ルールの登録・更新入力 (id / createdAt を除く)。 */
 export type KeywordRuleInput = Omit<KeywordRule, "id" | "createdAt">;
@@ -51,23 +84,77 @@ export type KeywordRuleTarget = {
   genres: number[];
 };
 
-/** KV から読んだ値のバリデーション用の型ガード。 */
+// バリデータは遅延構築 + memo 化する (上記の tree-shake 上の理由)。
+// readonly な as const スキーマは Validator のコンストラクタ型と合わないため
+// キャストする (実行時は問題ない)。
+type ValidatorSchema = ConstructorParameters<typeof Validator>[0];
+
+// 読み戻し検証は additionalProperties を緩める (型は厳格な as const から
+// 取り、実行時は寛容に — 既存データの未知キーで正当なルールを drop しない)。
+let fullValidatorInstance: Validator | null = null;
+function fullValidator(): Validator {
+  if (fullValidatorInstance === null) {
+    const readSchema = { ...keywordRuleSchema, additionalProperties: true };
+    fullValidatorInstance = new Validator(
+      readSchema as unknown as ValidatorSchema,
+      "7",
+    );
+  }
+  return fullValidatorInstance;
+}
+
+// 入力検証用スキーマは full から id / createdAt を除いて runtime 生成する
+// (入力の静的型は KeywordRuleInput = Omit<...> が担うため as const 不要)。
+let inputValidatorInstance: Validator | null = null;
+function inputValidator(): Validator {
+  if (inputValidatorInstance === null) {
+    const { id: _id, createdAt: _createdAt, ...properties } =
+      keywordRuleSchema.properties;
+    const inputSchema = {
+      type: "object",
+      additionalProperties: false,
+      properties,
+      required: keywordRuleSchema.required.filter(
+        (key) => key !== "id" && key !== "createdAt",
+      ),
+    };
+    inputValidatorInstance = new Validator(
+      inputSchema as unknown as ValidatorSchema,
+      "7",
+    );
+  }
+  return inputValidatorInstance;
+}
+
+/**
+ * undefined 値のキーを除く。Deno KV / V8 直列化は undefined を保持し、
+ * @cfworker のバリデータは undefined 値で例外を投げるため、検証前に均す。
+ */
+function withoutUndefined(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, v] of Object.entries(value)) {
+    if (v !== undefined) {
+      result[key] = v;
+    }
+  }
+  return result;
+}
+
+/** KV から読んだ値が KeywordRule か (keywordRuleSchema で検証)。 */
 export function isKeywordRule(value: unknown): value is KeywordRule {
   if (typeof value !== "object" || value === null) {
     return false;
   }
-  const rule = value as Record<string, unknown>;
-  return typeof rule.id === "string" &&
-    typeof rule.keyword === "string" &&
-    (rule.from === undefined || typeof rule.from === "string") &&
-    (rule.to === undefined || typeof rule.to === "string") &&
-    Array.isArray(rule.serviceIds) &&
-    Array.isArray(rule.genres) &&
-    typeof rule.enabled === "boolean" &&
-    typeof rule.createdAt === "number";
+  try {
+    return fullValidator().validate(
+      withoutUndefined(value as Record<string, unknown>),
+    ).valid;
+  } catch {
+    return false;
+  }
 }
-
-const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
 export type ParseResult =
   | { ok: true; input: KeywordRuleInput }
@@ -75,7 +162,9 @@ export type ParseResult =
 
 /**
  * API 入力をバリデーションして正規化する。keyword は trim、enabled は
- * 既定 true。期間は YYYY-MM-DD で開始 <= 終了 (同日可)。
+ * 既定 true、serviceIds / genres は既定 []、空の from / to は undefined。
+ * 構造は keywordRuleSchema (id / createdAt を除く) で検証し、期間の前後
+ * (from <= to、同日可) のみ別途検証する。
  */
 export function parseKeywordRuleInput(value: unknown): ParseResult {
   if (typeof value !== "object" || value === null) {
@@ -83,65 +172,53 @@ export function parseKeywordRuleInput(value: unknown): ParseResult {
   }
   const body = value as Record<string, unknown>;
 
-  if (typeof body.keyword !== "string" || body.keyword.trim() === "") {
-    return { ok: false, error: "keyword must be a non-empty string" };
-  }
-  const keyword = body.keyword.trim();
-
-  for (const key of ["from", "to"] as const) {
-    const date = body[key];
-    if (date !== undefined && date !== "" && date !== null) {
-      if (typeof date !== "string" || !DATE_PATTERN.test(date)) {
-        return { ok: false, error: `${key} must be a YYYY-MM-DD date` };
-      }
-    }
-  }
+  const keyword = typeof body.keyword === "string"
+    ? body.keyword.trim()
+    : body.keyword;
   const from = typeof body.from === "string" && body.from !== ""
     ? body.from
     : undefined;
   const to = typeof body.to === "string" && body.to !== ""
     ? body.to
     : undefined;
-  if (from !== undefined && to !== undefined && from > to) {
-    return { ok: false, error: "from must not be after to" };
-  }
-
   const serviceIds = body.serviceIds ?? [];
-  if (
-    !Array.isArray(serviceIds) ||
-    serviceIds.some((id) => typeof id !== "number" || !Number.isFinite(id))
-  ) {
-    return { ok: false, error: "serviceIds must be an array of numbers" };
-  }
-
   const genres = body.genres ?? [];
-  if (
-    !Array.isArray(genres) ||
-    genres.some(
-      (lv1) =>
-        typeof lv1 !== "number" || !Number.isInteger(lv1) ||
-        lv1 < 0 || lv1 > 15,
-    )
-  ) {
+  const enabled = body.enabled === undefined ? true : body.enabled;
+
+  // 検証用オブジェクトは undefined キーを持たせない (@cfworker 対策)。
+  const candidate = withoutUndefined({
+    keyword,
+    from,
+    to,
+    serviceIds,
+    genres,
+    enabled,
+  });
+
+  const result = inputValidator().validate(candidate);
+  if (!result.valid) {
+    const first = result.errors[0];
     return {
       ok: false,
-      error: "genres must be an array of ARIB lv1 codes (0..15)",
+      error: first
+        ? `${first.instanceLocation || "/"} ${first.error}`
+        : "invalid input",
     };
   }
 
-  if (body.enabled !== undefined && typeof body.enabled !== "boolean") {
-    return { ok: false, error: "enabled must be a boolean" };
+  if (from !== undefined && to !== undefined && from > to) {
+    return { ok: false, error: "from must not be after to" };
   }
 
   return {
     ok: true,
     input: {
-      keyword,
+      keyword: keyword as string,
       from,
       to,
       serviceIds: serviceIds as number[],
       genres: genres as number[],
-      enabled: body.enabled === undefined ? true : body.enabled,
+      enabled: enabled as boolean,
     },
   };
 }


### PR DESCRIPTION
## 概要

設定系データの管理を **JSON Schema 正本**に寄せる試験移行。対象は keyword-rules 1 系統（#46 の方針検証）。1 個の `keywordRuleSchema` から、静的型（json-schema-to-ts の `FromSchema`）と実行時検証（@cfworker/json-schema）の両方を導出する。Zod は使わない。

## 背景

#46 で決めた方針:

- ストレージは Deno KV 据え置き。
- スキーマの単一ソース化は **JSON Schema**（型と実行時検証を 1 宣言から導出）。バリデータは依存ゼロ・eval なしの **@cfworker/json-schema**（spike で Deno 動作確認済み）。
- 読み戻し正規化は寛容に倒す（壊れた値で全体を捨てない）。

## 変更点

- `KeywordRule` 型を手書きから `FromSchema<typeof keywordRuleSchema>` 由来に置換。
- `isKeywordRule` / `parseKeywordRuleInput` をスキーマ検証ベースに置換。型・範囲・日付書式はスキーマに集約し、**正規化**（trim・既定値補完）と**フィールド間条件**（`from <= to`）のみ手書きで残す。
- **読み戻しは `additionalProperties` を緩める**。未知キーがあっても正当な値を drop しない（入力は厳格・読み戻しは寛容、の非対称を維持）。
- **undefined 値の均し**。KV / V8 直列化は `from: undefined` 等を保持し、@cfworker はその undefined 値で例外を投げる。検証前に undefined キーを除く。
- **バリデータは遅延構築**。client は `matchesKeywordRule` のみ runtime import するため、最上位で構築すると @cfworker が client バンドルに混入する。遅延構築で tree-shake させる。
- `isKeywordRule` のユニットテストを追加（従来テスト無し）。寛容読み戻し・undefined 処理・スキーマ制約を固定。

## 波及範囲

公開 API（`KeywordRule` / `KeywordRuleInput` / `isKeywordRule` / `parseKeywordRuleInput`）の名前・形を維持したため、**store / routes / client は無変更**。差分は 4 ファイル（`server/lib/keyword-rules.ts`、同 `.test.ts`、`deno.json`、`deno.lock`）のみ。

## 確認

- `deno task check`（型・プロジェクト全体）通過。FromSchema 由来の型が client 全使用箇所と整合。
- `deno lint`（227 files）/ `deno fmt --check`（変更ファイル）通過。
- `deno task test:server` / `deno task test:client` 通過。
- `deno task build` 通過。**client/dist に @cfworker 由来の文字列・スキーマ文字列が一切出ないことを grep で確認**（tree-shake で server 専用を維持）。

## スコープ外（後続）

- notification / live-comment への横展開。
- `description` フィールドからの `docs/kv-data.md`（データ辞書）生成。

Refs #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)
