### PR TITLE
refactor: キーワードルールの読み戻し検証を OpenAPI スキーマ単一ソース化

### DIFF
--- a/server/lib/api/validate.ts
+++ b/server/lib/api/validate.ts
@@ -38,6 +38,56 @@ export function matchesSchema(
   return validatorFor(name).validate(value).valid;
 }
 
+const storedValidators = new Map<InternalSchemaName, Validator>();
+
+function storedValidatorFor(name: InternalSchemaName): Validator {
+  let validator = storedValidators.get(name);
+  if (validator === undefined) {
+    // 読み戻しは additionalProperties を緩める。生成スキーマは
+    // additionalProperties:false で閉じているが、KV に残る旧スキーマの未知キーを
+    // 理由に正当な値を drop しないため、構造検証だけ寛容にする。
+    const schema = { ...internalSchemas[name], additionalProperties: true };
+    validator = new Validator(schema as unknown as Schema, "2020-12");
+    storedValidators.set(name, validator);
+  }
+  return validator;
+}
+
+/** プレーンオブジェクトから undefined 値のキーを除く (それ以外はそのまま返す)。 */
+function withoutUndefined(value: unknown): unknown {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return value;
+  }
+  const result: Record<string, unknown> = {};
+  for (const [key, v] of Object.entries(value)) {
+    if (v !== undefined) {
+      result[key] = v;
+    }
+  }
+  return result;
+}
+
+/**
+ * KV から読み戻した値が name のスキーマに構造適合するかを判定する (読み戻し用)。
+ * 入力検証 (matchesSchema) との非対称を意図的に作る:
+ *
+ * - additionalProperties を緩める (storedValidatorFor 参照)。
+ * - undefined 値のキーを検証前に均す。Deno KV / V8 直列化は `from: undefined`
+ *   などのキーを保持し、@cfworker はその undefined 値で例外を投げるため。
+ *
+ * 例外時は false を返し、型ガードとして throw しないことを保証する。
+ */
+export function matchesStoredSchema(
+  name: InternalSchemaName,
+  value: unknown,
+): boolean {
+  try {
+    return storedValidatorFor(name).validate(withoutUndefined(value)).valid;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * 検証エラーの先頭を `<instanceLocation>: <error>` の形に整形して返す。
  * matchesSchema が false のときの API エラーメッセージに使う。

--- a/server/lib/keyword-rules.test.ts
+++ b/server/lib/keyword-rules.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "@std/assert";
 import {
+  isKeywordRule,
   type KeywordRule,
   matchesKeywordRule,
   parseKeywordRuleInput,
@@ -7,7 +8,8 @@ import {
 
 function rule(overrides: Partial<KeywordRule> = {}): KeywordRule {
   return {
-    id: "r1",
+    // id は uuid (生成スキーマの format: uuid を満たす実データ相当)。
+    id: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
     keyword: "ニュース",
     serviceIds: [],
     genres: [],
@@ -179,4 +181,50 @@ Deno.test("parseKeywordRuleInput: 不正値は ok:false", () => {
     to: "2026-01-01T23:59:59+09:00",
   });
   assertEquals(sameDay.ok, true);
+});
+
+Deno.test("isKeywordRule: 正当な保存値を受け入れる", () => {
+  assertEquals(isKeywordRule(rule()), true);
+  assertEquals(
+    isKeywordRule(
+      rule({
+        from: "2026-01-01T00:00:00+09:00",
+        to: "2026-01-31T23:59:59+09:00",
+      }),
+    ),
+    true,
+  );
+  // 期間未指定は from / to が undefined キーで保存される (KV / V8 直列化は
+  // undefined を保持する)。検証前に均すため drop されないこと。
+  assertEquals(
+    isKeywordRule({ ...rule(), from: undefined, to: undefined }),
+    true,
+  );
+  // 未知キーがあっても寛容に受け入れる (読み戻しは additionalProperties 緩め)。
+  assertEquals(isKeywordRule({ ...rule(), legacyField: 1 }), true);
+});
+
+Deno.test("isKeywordRule: 壊れた値は除外する", () => {
+  const broken: unknown[] = [
+    null,
+    undefined,
+    "rule",
+    123,
+    {},
+    // 必須キー (id / createdAt) 欠落。
+    { keyword: "x", serviceIds: [], genres: [], enabled: true },
+    // 型違い。
+    { ...rule(), createdAt: "x" },
+    { ...rule(), enabled: "yes" },
+    { ...rule(), serviceIds: "x" },
+    // 範囲外ジャンル (minimum / maximum はアサーションとして効く)。
+    { ...rule(), genres: [16] },
+    { ...rule(), genres: [-1] },
+    // format 違反 (@cfworker は format も検証する)。
+    { ...rule(), id: "r1" }, // uuid でない
+    { ...rule(), from: "2026-01-01" }, // RFC 3339 date-time でない (旧 YYYY-MM-DD)
+  ];
+  for (const value of broken) {
+    assertEquals(isKeywordRule(value), false, JSON.stringify(value));
+  }
 });

--- a/server/lib/keyword-rules.ts
+++ b/server/lib/keyword-rules.ts
@@ -8,7 +8,11 @@
  */
 import type { FromSchema } from "json-schema-to-ts";
 import { internalSchemas } from "./api/internal-schemas.ts";
-import { matchesSchema, schemaErrorOf } from "./api/validate.ts";
+import {
+  matchesSchema,
+  matchesStoredSchema,
+  schemaErrorOf,
+} from "./api/validate.ts";
 
 /**
  * キーワード自動録画のルール。docs/api の OpenAPI から生成した component
@@ -35,20 +39,16 @@ export type KeywordRuleTarget = {
   genres: number[];
 };
 
-/** KV から読んだ値のバリデーション用の型ガード。 */
+/**
+ * KV から読み戻した値が KeywordRule か。型の単一ソースである生成スキーマ
+ * (internal-schemas.ts) で検証する。@cfworker は format も検証するため、id の
+ * uuid と from / to の RFC 3339 date-time もここで担保される。読み戻しは寛容で、
+ * 未知キーを許し undefined 値のキーを均す (詳細は matchesStoredSchema)。
+ * keyword の非空 (スキーマに minLength は無い) と from <= to は入力側
+ * (parseKeywordRuleInput) の責務で、ここでは見ない。
+ */
 export function isKeywordRule(value: unknown): value is KeywordRule {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-  const rule = value as Record<string, unknown>;
-  return typeof rule.id === "string" &&
-    typeof rule.keyword === "string" &&
-    (rule.from === undefined || typeof rule.from === "string") &&
-    (rule.to === undefined || typeof rule.to === "string") &&
-    Array.isArray(rule.serviceIds) &&
-    Array.isArray(rule.genres) &&
-    typeof rule.enabled === "boolean" &&
-    typeof rule.createdAt === "number";
+  return matchesStoredSchema("KeywordRule", value);
 }
 
 /** RFC 3339 日時文字列を Temporal.Instant にする。不正なら null (オフセット必須)。 */

--- a/server/store/keyword-rules.test.ts
+++ b/server/store/keyword-rules.test.ts
@@ -48,8 +48,8 @@ Deno.test("add: 条件付きルールの全項目を保存する", async () => {
     const rule = await store.add(
       input({
         keyword: "ドラマ",
-        from: "2026-01-01",
-        to: "2026-01-31",
+        from: "2026-01-01T00:00:00+09:00",
+        to: "2026-01-31T23:59:59+09:00",
         serviceIds: [3273601024],
         genres: [3],
         enabled: false,
@@ -57,7 +57,7 @@ Deno.test("add: 条件付きルールの全項目を保存する", async () => {
       0,
     );
     assertEquals((await store.list())[0], rule);
-    assertEquals(rule.from, "2026-01-01");
+    assertEquals(rule.from, "2026-01-01T00:00:00+09:00");
     assertEquals(rule.serviceIds, [3273601024]);
     assertEquals(rule.genres, [3]);
     assertEquals(rule.enabled, false);


### PR DESCRIPTION
## 概要

キーワード自動録画ルールの **読み戻し検証 (`isKeywordRule`)** を、docs/api の OpenAPI から生成した component schema (`server/lib/api/internal-schemas.ts`) を単一ソースとする検証に置き換える。

#48 (クローズ済) は独立した `keywordRuleSchema` を正本にする試験移行だったが、その後 #49 で OpenAPI を単一ソースとする基盤が入り、型 (`FromSchema`) と入力検証 (`parseKeywordRuleInput` の `matchesSchema`) は既に移行済みになった。唯一手書きのまま残っていた `isKeywordRule` を、同じ基盤に載せ替えるのが本 PR。#48 は破棄し、main の OpenAPI 型定義に合わせて再実装した。

## 変更点

- **`server/lib/api/validate.ts`**: 読み戻し用 `matchesStoredSchema(name, value)` を追加。入力検証 `matchesSchema` との非対称を意図的に作る。
  - `additionalProperties` を緩める — KV に残る旧スキーマの未知キーを理由に正当な値を drop しない。
  - 検証前に undefined 値のキーを均す — Deno KV / V8 直列化は `from: undefined` などのキーを保持し、`@cfworker` はその undefined 値で例外を投げるため。
  - 例外時は false を返し、型ガードとして throw しないことを保証する。
- **`server/lib/keyword-rules.ts`**: 手書きの `isKeywordRule` を `matchesStoredSchema("KeywordRule", value)` の薄いラッパに置換。
- **`server/lib/keyword-rules.test.ts`**: `isKeywordRule` のユニットテストを追加 (寛容受理・構造/format 違反の除外)。`rule()` フィクスチャの id を有効な uuid に。
- **`server/store/keyword-rules.test.ts`**: from/to のフィクスチャが #49 の取りこぼしで旧 `YYYY-MM-DD` のままだったため、RFC 3339 date-time に修正。

## 設計判断: 読み戻しで format も担保する

調査中に判明した事実として、**`@cfworker/json-schema` は `format` をデフォルトで assert する** (JSON Schema 2020-12 の「format は annotation のみ」既定に反する)。生成スキーマは `id: format uuid` / `from, to: format date-time` を持つため、読み戻しでも書式が担保される。

読み戻しの寛容化は **`additionalProperties` と undefined 均しに限定し、format は緩めない** 方針を採った。現行コードが生成する id (uuid) と from/to (RFC 3339) は必ず適合するため実データは落ちない。

副作用として、**#49 以前の旧 `YYYY-MM-DD` の from/to を持つ保存値は読み戻しで drop される**。ただし #49 で from/to が date-time に変わった時点で、そのような旧データの期間フィルタは既に機能しなくなっている。

## 確認

- `deno task test:server` — 92 passed / 0 failed
- `deno task test:client` — 251 passed / 0 failed
- `deno task check` (fmt + lint + 型チェック) — 通過
- `deno task build` 後、`client/dist` に `@cfworker` / `internalSchemas` が出ないことを grep で確認 (tree-shake で server 専用を維持)

Refs #46, #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)
