### PR TITLE
refactor: キーワード自動録画のチャンネル設定を Channel 単位へ移行

### DIFF
--- a/.claude/rules/keyword-recording.md
+++ b/.claude/rules/keyword-recording.md
@@ -10,7 +10,7 @@
   - **ルールの登録・更新**: `/api/keyword-rules` の POST / PUT 成功時に `onChanged` フックで `job.trigger()`（同じ debounce 経由。削除では発火しない — 予約の取り消しはしない仕様のため再実行で増える予約が無い）
   - フォールバックの定期実行: `KEYWORD_RECORDING_INTERVAL_MINUTES`（既定 60 分）間隔（Deno.cron 相当。`Deno.cron` は使わない）
 - 実行中の再要求は完了後に 1 回へ畳む（並行実行で二重予約させない）。
-- mirakc の `/programs`・`/services`・`/recording/schedules` を取得し、**有効ルール**に `matchesKeywordRule` で一致する**未予約・将来**の番組を `POST /recording/schedules` で予約する。チャンネル条件は (networkId, serviceId) → 複合 service id の解決を経て判定。
+- mirakc の `/programs`・`/services`・`/recording/schedules` を取得し、**有効ルール**に `matchesKeywordRule` で一致する**未予約・将来**の番組を `POST /recording/schedules` で予約する。チャンネル条件は (networkId, serviceId) → サービスの `channel.channel`（= MirakurunChannel.channel）の解決を経て判定。チャンネル配下の全サービスを横断して対象になる。
 - 予約には tag `mirakc-ui:keyword` と `keyword:<キーワード>` を付ける。`contentPath` は手動予約と同じ `{YYYYMMDDhhmmss}_{programId}_{番組名}.m2ts`。
 - 登録時の通知はキーワード・チャンネル名・放送時間入り（`notification.keyword.*`）。予約処理自体は通知設定に関係なく実行する。
 
@@ -33,7 +33,7 @@
 
 - `keyword` — 番組名（name のみ、description は対象外）の部分一致。大文字小文字無視
 - `from` / `to` — ローカル日付 `YYYY-MM-DD`、両端含む。未指定は無制限
-- `serviceIds` — Mirakurun の複合 service id の配列。空 = 全チャンネル
+- `channels` — チャンネル（`MirakurunChannel.channel`、例 `"27"` / `"BS15_0"`）の配列。空 = 全チャンネル。チャンネル単位で指定し、配下の全サービスを横断して対象にする。旧 `serviceIds`（複合 service id）形式の保存値は読み戻し時に `channels: []`（全チャンネル）へフォールバックする（`server/store/keyword-rules.ts` の `normalizeStoredKeywordRule`。service→channel の解決に mirakc データが要るため自動変換はしない）
 - `genres` — ARIB lv1 コード (0..15) の配列。空 = 全ジャンル（交差判定）
 - `enabled` — 停止中は自動予約の対象外
 

--- a/client/components/organisms/KeywordRules/RuleCard.stories.tsx
+++ b/client/components/organisms/KeywordRules/RuleCard.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import RuleCard from "./RuleCard.tsx";
-import { sampleServices } from "../../../lib/fixtures.ts";
+import { sampleChannelGroups } from "../../../lib/fixtures.ts";
 
 const meta = {
   title: "organisms/KeywordRules/RuleCard",
@@ -11,12 +11,12 @@ const meta = {
       keyword: "サッカー",
       from: "2026-06-01",
       to: "2026-06-30",
-      serviceIds: [3274001040],
+      channels: ["25"],
       genres: [1],
       enabled: true,
       createdAt: 0,
     },
-    services: sampleServices,
+    channels: sampleChannelGroups,
     matchCount: 4,
     onToggle: () => {},
     onEdit: () => {},
@@ -36,7 +36,7 @@ export const NoConditions: Story = {
     rule: {
       id: "b",
       keyword: "ニュース",
-      serviceIds: [],
+      channels: [],
       genres: [],
       enabled: true,
       createdAt: 0,
@@ -50,7 +50,7 @@ export const Disabled: Story = {
     rule: {
       id: "c",
       keyword: "ドラマ",
-      serviceIds: [],
+      channels: [],
       genres: [3],
       enabled: false,
       createdAt: 0,
@@ -67,7 +67,7 @@ export const MultipleChannels: Story = {
     rule: {
       id: "d",
       keyword: "クイズ",
-      serviceIds: [3273601024, 3274001040, 3274101048, 4100101000],
+      channels: ["27", "25", "24", "BS15_0"],
       genres: [],
       enabled: true,
       createdAt: 0,

--- a/client/components/organisms/KeywordRules/RuleCard.test.tsx
+++ b/client/components/organisms/KeywordRules/RuleCard.test.tsx
@@ -2,14 +2,14 @@ import { describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import RuleCard from "./RuleCard.tsx";
 import type { KeywordRule } from "../../../lib/api/keyword-rules.ts";
-import { sampleServices } from "../../../lib/fixtures.ts";
+import { sampleChannelGroups } from "../../../lib/fixtures.ts";
 import { t } from "../../../locales/i18n.ts";
 
 function ruleOf(overrides: Partial<KeywordRule> = {}): KeywordRule {
   return {
     id: "a",
     keyword: "ニュース",
-    serviceIds: [],
+    channels: [],
     genres: [],
     enabled: true,
     createdAt: 0,
@@ -20,7 +20,7 @@ function ruleOf(overrides: Partial<KeywordRule> = {}): KeywordRule {
 function setup(override: Partial<Parameters<typeof RuleCard>[0]> = {}) {
   const props = {
     rule: ruleOf(),
-    services: sampleServices,
+    channels: sampleChannelGroups,
     matchCount: 3,
     onToggle: vi.fn(),
     onEdit: vi.fn(),
@@ -57,7 +57,7 @@ describe("RuleCard", () => {
       rule: ruleOf({
         from: "2026-01-01",
         to: "2026-01-31",
-        serviceIds: [3273601024],
+        channels: ["27"],
         genres: [0],
       }),
     });
@@ -69,7 +69,7 @@ describe("RuleCard", () => {
   });
 
   it("複数チャンネルは件数表記にする", () => {
-    setup({ rule: ruleOf({ serviceIds: [3273601024, 3273701032] }) });
+    setup({ rule: ruleOf({ channels: ["27", "26"] }) });
     expect(
       screen.getByText(t("keyword.card.channels", { count: 2 })),
     ).toBeTruthy();

--- a/client/components/organisms/KeywordRules/RuleCard.tsx
+++ b/client/components/organisms/KeywordRules/RuleCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import type { components } from "../../../lib/api/schema.d.ts";
 import type { KeywordRule } from "../../../lib/api/keyword-rules.ts";
+import type { ChannelGroup } from "../../../lib/service.ts";
 import { genreByLv1 } from "../../../lib/genre.ts";
 import Icon from "../../atoms/Icon.tsx";
 import IconButton from "../../atoms/IconButton.tsx";
@@ -10,14 +10,12 @@ import GenreTag from "../../atoms/GenreTag.tsx";
 import { t } from "../../../locales/i18n.ts";
 import styles from "./RuleCard.module.css";
 
-type Service = components["schemas"]["MirakurunService"];
-
 type Props = {
   /** 表示するルール。 */
   rule: KeywordRule;
 
-  /** チャンネル条件チップの表示に使うサービス一覧。 */
-  services: Service[];
+  /** チャンネル条件チップの表示に使うチャンネル一覧。 */
+  channels: ChannelGroup[];
 
   /** 今後 7 日間の一致番組数。 */
   matchCount: number;
@@ -58,16 +56,16 @@ function periodLabel(rule: KeywordRule): string | null {
 }
 
 /** 条件チップ列。期間 → チャンネル → ジャンルの順、条件なしは案内文。 */
-function ConditionChips({ rule, services }: Pick<Props, "rule" | "services">) {
+function ConditionChips({ rule, channels }: Pick<Props, "rule" | "channels">) {
   const period = periodLabel(rule);
-  const channels = rule.serviceIds
-    .map((id) => services.find((service) => service.id === id))
-    .filter((service): service is Service => service !== undefined);
+  const selected = rule.channels
+    .map((id) => channels.find((channel) => channel.id === id))
+    .filter((channel): channel is ChannelGroup => channel !== undefined);
   // 同じキーに丸まる lv1 (12..15 → other) を重複表示しない。
   const genreKeys = [...new Set(rule.genres.map((lv1) => genreByLv1(lv1).key))];
 
   if (
-    period === null && rule.serviceIds.length === 0 && genreKeys.length === 0
+    period === null && rule.channels.length === 0 && genreKeys.length === 0
   ) {
     return (
       <span className={styles.condNone}>{t("keyword.card.conditionNone")}</span>
@@ -82,15 +80,23 @@ function ConditionChips({ rule, services }: Pick<Props, "rule" | "services">) {
           <span className={styles.mono}>{period}</span>
         </span>
       )}
-      {rule.serviceIds.length > 0 && (
+      {rule.channels.length > 0 && (
         <span className={styles.chip}>
-          {channels.slice(0, 3).map((service) => (
-            <ChannelBadge key={service.id} service={service} size="xs" />
-          ))}
+          {selected.slice(0, 3).map((channel) =>
+            channel.services[0]
+              ? (
+                <ChannelBadge
+                  key={channel.id}
+                  service={channel.services[0]}
+                  size="xs"
+                />
+              )
+              : null
+          )}
           <span>
-            {rule.serviceIds.length === 1
-              ? channels[0]?.name ?? ""
-              : t("keyword.card.channels", { count: rule.serviceIds.length })}
+            {rule.channels.length === 1
+              ? selected[0]?.name ?? rule.channels[0]
+              : t("keyword.card.channels", { count: rule.channels.length })}
           </span>
         </span>
       )}
@@ -140,7 +146,7 @@ export default function RuleCard(props: Props) {
           )}
         </div>
         <div className={styles.conds}>
-          <ConditionChips rule={rule} services={props.services} />
+          <ConditionChips rule={rule} channels={props.channels} />
         </div>
       </div>
 

--- a/client/components/organisms/KeywordRules/RuleFormModal.stories.tsx
+++ b/client/components/organisms/KeywordRules/RuleFormModal.stories.tsx
@@ -1,7 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import RuleFormModal from "./RuleFormModal.tsx";
 import { buildUpcoming } from "../../../lib/keyword-preview.ts";
-import { samplePrograms, sampleServices } from "../../../lib/fixtures.ts";
+import {
+  sampleChannelGroups,
+  samplePrograms,
+  sampleServices,
+} from "../../../lib/fixtures.ts";
 import { nowEpochMs } from "../../../lib/datetime.ts";
 
 const upcoming = buildUpcoming(samplePrograms, sampleServices, nowEpochMs());
@@ -12,7 +16,7 @@ const meta = {
   parameters: { layout: "fullscreen" },
   args: {
     open: true,
-    services: sampleServices,
+    channels: sampleChannelGroups,
     upcoming,
     onSave: () => {},
     onClose: () => {},
@@ -34,7 +38,7 @@ export const Edit: Story = {
       keyword: "ニュース",
       from: "2026-06-01",
       to: "2026-06-30",
-      serviceIds: [3273601024, 4100101000],
+      channels: ["27", "BS15_0"],
       genres: [0],
       enabled: true,
       createdAt: 0,
@@ -49,7 +53,7 @@ export const Busy: Story = {
     initial: {
       id: "a",
       keyword: "ニュース",
-      serviceIds: [],
+      channels: [],
       genres: [],
       enabled: true,
       createdAt: 0,

--- a/client/components/organisms/KeywordRules/RuleFormModal.test.tsx
+++ b/client/components/organisms/KeywordRules/RuleFormModal.test.tsx
@@ -4,7 +4,11 @@ import RuleFormModal from "./RuleFormModal.tsx";
 import type { KeywordRule } from "../../../lib/api/keyword-rules.ts";
 import { buildUpcoming } from "../../../lib/keyword-preview.ts";
 import { localEndOfDay, localStartOfDay } from "../../../lib/datetime.ts";
-import { buildSamplePrograms, sampleServices } from "../../../lib/fixtures.ts";
+import {
+  buildSamplePrograms,
+  sampleChannelGroups,
+  sampleServices,
+} from "../../../lib/fixtures.ts";
 import { t } from "../../../locales/i18n.ts";
 
 const now = Date.UTC(2026, 5, 10, 12, 0, 0);
@@ -15,7 +19,7 @@ const upcoming = buildUpcoming(programs, sampleServices, now);
 function setup(override: Partial<Parameters<typeof RuleFormModal>[0]> = {}) {
   const props = {
     open: true,
-    services: sampleServices,
+    channels: sampleChannelGroups,
     upcoming,
     onSave: vi.fn(),
     onClose: vi.fn(),
@@ -113,7 +117,7 @@ describe("RuleFormModal", () => {
         keyword: "ニュース",
         from: undefined,
         to: undefined,
-        serviceIds: [3273601024],
+        channels: ["27"],
         genres: [0],
         enabled: true,
       })
@@ -126,7 +130,7 @@ describe("RuleFormModal", () => {
       keyword: "ドラマ",
       from: localStartOfDay("2026-06-01"),
       to: localEndOfDay("2026-06-30"),
-      serviceIds: [3273601024],
+      channels: ["27"],
       genres: [3],
       enabled: false,
       createdAt: 0,
@@ -144,7 +148,7 @@ describe("RuleFormModal", () => {
         keyword: "ドラマ",
         from: localStartOfDay("2026-06-01"),
         to: localEndOfDay("2026-06-30"),
-        serviceIds: [3273601024],
+        channels: ["27"],
         genres: [3],
         enabled: false,
       })

--- a/client/components/organisms/KeywordRules/RuleFormModal.tsx
+++ b/client/components/organisms/KeywordRules/RuleFormModal.tsx
@@ -1,5 +1,4 @@
 import { useForm } from "@tanstack/react-form";
-import type { components } from "../../../lib/api/schema.d.ts";
 import { matchesKeywordRule } from "../../../../server/lib/keyword-rules.ts";
 import type {
   KeywordRule,
@@ -7,7 +6,11 @@ import type {
 } from "../../../lib/api/keyword-rules.ts";
 import type { UpcomingProgram } from "../../../lib/keyword-preview.ts";
 import { GENRES, genreVars } from "../../../lib/genre.ts";
-import { CHANNEL_TYPES, channelTypeLabel } from "../../../lib/service.ts";
+import {
+  type ChannelGroup,
+  CHANNEL_TYPES,
+  channelTypeLabel,
+} from "../../../lib/service.ts";
 import {
   dateOf,
   formatHm,
@@ -22,8 +25,6 @@ import ChannelBadge from "../../atoms/ChannelBadge.tsx";
 import { t } from "../../../locales/i18n.ts";
 import styles from "./RuleFormModal.module.css";
 
-type Service = components["schemas"]["MirakurunService"];
-
 type Props = {
   /** 表示状況。 */
   open: boolean;
@@ -31,8 +32,8 @@ type Props = {
   /** 編集対象。未指定なら新規登録。 */
   initial?: KeywordRule;
 
-  /** チャンネル選択肢にするサービス一覧。 */
-  services: Service[];
+  /** チャンネル選択肢にするチャンネル一覧。 */
+  channels: ChannelGroup[];
 
   /** 一致プレビューの対象 (今後 7 日間の番組)。 */
   upcoming: UpcomingProgram[];
@@ -77,7 +78,7 @@ export default function RuleFormModal(props: Props) {
       // API 上は TZ 付き日時だが UI は日付ピッカーのため日付部分だけを保持する。
       from: dateOf(initial?.from),
       to: dateOf(initial?.to),
-      serviceIds: (initial?.serviceIds ?? []) as number[],
+      channels: (initial?.channels ?? []) as string[],
       genres: (initial?.genres ?? []) as number[],
     },
     onSubmit: ({ value }) => {
@@ -89,7 +90,7 @@ export default function RuleFormModal(props: Props) {
         // 日付を当日の 00:00:00 / 23:59:59 (ローカル TZ オフセット付き) に補う。
         from: value.from === "" ? undefined : localStartOfDay(value.from),
         to: value.to === "" ? undefined : localEndOfDay(value.to),
-        serviceIds: value.serviceIds,
+        channels: value.channels,
         genres: value.genres,
         enabled: initial?.enabled ?? true,
       });
@@ -203,10 +204,10 @@ export default function RuleFormModal(props: Props) {
             }}
           </form.Subscribe>
 
-          <form.Field name="serviceIds">
+          <form.Field name="channels">
             {(field) => {
               const selected = field.state.value;
-              const toggle = (id: number) =>
+              const toggle = (id: string) =>
                 field.handleChange(
                   selected.includes(id)
                     ? selected.filter((x) => x !== id)
@@ -238,8 +239,8 @@ export default function RuleFormModal(props: Props) {
                       )}
                   </div>
                   {CHANNEL_TYPES.map((channelType) => {
-                    const group = props.services.filter(
-                      (service) => service.channel.type === channelType,
+                    const group = props.channels.filter(
+                      (channel) => channel.type === channelType,
                     );
                     if (group.length === 0) {
                       return null;
@@ -250,20 +251,25 @@ export default function RuleFormModal(props: Props) {
                           {channelTypeLabel(channelType)}
                         </div>
                         <div className={styles.channelGrid}>
-                          {group.map((service) => (
+                          {group.map((channel) => (
                             <button
                               type="button"
-                              key={service.id}
+                              key={channel.id}
                               className={`${styles.channelOption} ${
-                                selected.includes(service.id)
+                                selected.includes(channel.id)
                                   ? styles.channelOn
                                   : ""
                               }`}
-                              onClick={() => toggle(service.id)}
+                              onClick={() => toggle(channel.id)}
                             >
-                              <ChannelBadge service={service} size="xs" />
+                              {channel.services[0] && (
+                                <ChannelBadge
+                                  service={channel.services[0]}
+                                  size="xs"
+                                />
+                              )}
                               <span className={styles.channelName}>
-                                {service.name}
+                                {channel.name}
                               </span>
                             </button>
                           ))}
@@ -351,7 +357,7 @@ export default function RuleFormModal(props: Props) {
                   ? undefined
                   : localStartOfDay(values.from),
                 to: values.to === "" ? undefined : localEndOfDay(values.to),
-                serviceIds: values.serviceIds,
+                channels: values.channels,
                 genres: values.genres,
               };
               const matches = normalized === ""

--- a/client/components/templates/KeywordRules.stories.tsx
+++ b/client/components/templates/KeywordRules.stories.tsx
@@ -1,6 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import KeywordRulesTemplate from "./KeywordRules.tsx";
-import { samplePrograms, sampleServices } from "../../lib/fixtures.ts";
+import {
+  sampleChannelGroups,
+  samplePrograms,
+  sampleServices,
+} from "../../lib/fixtures.ts";
 import { nowEpochMs } from "../../lib/datetime.ts";
 
 const meta = {
@@ -12,7 +16,7 @@ const meta = {
       {
         id: "a",
         keyword: "ニュース",
-        serviceIds: [],
+        channels: [],
         genres: [0],
         enabled: true,
         createdAt: 3,
@@ -20,7 +24,7 @@ const meta = {
       {
         id: "b",
         keyword: "サッカー",
-        serviceIds: [3274001040, 3273601024],
+        channels: ["25", "27"],
         genres: [],
         enabled: true,
         createdAt: 2,
@@ -30,13 +34,14 @@ const meta = {
         keyword: "ドラマ",
         from: "2026-06-01",
         to: "2026-06-30",
-        serviceIds: [],
+        channels: [],
         genres: [3],
         enabled: false,
         createdAt: 1,
       },
     ],
     services: sampleServices,
+    channels: sampleChannelGroups,
     programs: samplePrograms,
     currentEpochMs: nowEpochMs(),
     onAdd: () => {},

--- a/client/components/templates/KeywordRules.test.tsx
+++ b/client/components/templates/KeywordRules.test.tsx
@@ -2,7 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import KeywordRulesTemplate from "./KeywordRules.tsx";
 import type { KeywordRule } from "../../lib/api/keyword-rules.ts";
-import { buildSamplePrograms, sampleServices } from "../../lib/fixtures.ts";
+import {
+  buildSamplePrograms,
+  sampleChannelGroups,
+  sampleServices,
+} from "../../lib/fixtures.ts";
 import { t } from "../../locales/i18n.ts";
 
 const now = Date.UTC(2026, 5, 10, 12, 0, 0);
@@ -12,7 +16,7 @@ function ruleOf(overrides: Partial<KeywordRule> = {}): KeywordRule {
   return {
     id: "a",
     keyword: "ニュース",
-    serviceIds: [],
+    channels: [],
     genres: [],
     enabled: true,
     createdAt: 0,
@@ -26,6 +30,7 @@ function setup(
   const props = {
     rules: [ruleOf(), ruleOf({ id: "b", keyword: "映画", enabled: false })],
     services: sampleServices,
+    channels: sampleChannelGroups,
     programs,
     currentEpochMs: now,
     onAdd: vi.fn(),

--- a/client/components/templates/KeywordRules.tsx
+++ b/client/components/templates/KeywordRules.tsx
@@ -2,6 +2,7 @@ import { type ReactNode, useMemo } from "react";
 import type { components } from "../../lib/api/schema.d.ts";
 import { matchesKeywordRule } from "../../../server/lib/keyword-rules.ts";
 import type { KeywordRule } from "../../lib/api/keyword-rules.ts";
+import type { ChannelGroup } from "../../lib/service.ts";
 import { buildUpcoming } from "../../lib/keyword-preview.ts";
 import Icon from "../atoms/Icon.tsx";
 import PageHeader from "../organisms/PageHeader.tsx";
@@ -17,8 +18,11 @@ type Props = {
   /** 登録済みルール一覧。 */
   rules: KeywordRule[];
 
-  /** チャンネル条件チップの表示に使うサービス一覧。 */
+  /** 一致プレビュー (今後 7 日間) の組み立てに使うサービス一覧。 */
   services: Service[];
+
+  /** チャンネル条件チップの表示に使うチャンネル一覧。 */
+  channels: ChannelGroup[];
 
   /** 一致件数の対象にする番組一覧。 */
   programs: Program[];
@@ -175,7 +179,7 @@ export default function KeywordRules(props: Props) {
                     <li key={rule.id}>
                       <RuleCard
                         rule={rule}
-                        services={props.services}
+                        channels={props.channels}
                         matchCount={matchCounts.get(rule.id) ?? 0}
                         disabled={props.busy}
                         onToggle={() => props.onToggle(rule)}

--- a/client/lib/api/keyword-rules.test.ts
+++ b/client/lib/api/keyword-rules.test.ts
@@ -9,7 +9,7 @@ import {
 const rule = {
   id: "a",
   keyword: "ニュース",
-  serviceIds: [],
+  channels: [],
   genres: [],
   enabled: true,
   createdAt: 1,
@@ -19,7 +19,7 @@ const input = {
   keyword: "ニュース",
   from: "2026-01-01",
   to: undefined,
-  serviceIds: [3273601024],
+  channels: ["27"],
   genres: [0],
   enabled: true,
 };

--- a/client/lib/fixtures.ts
+++ b/client/lib/fixtures.ts
@@ -1,8 +1,10 @@
 import type { components } from "./api/schema.d.ts";
 import type { LiveComment } from "./live-comment.ts";
+import { buildChannelGroups, type ChannelGroup } from "./service.ts";
 import { nowEpochMs, startOfHourEpochMs } from "./datetime.ts";
 
 type Service = components["schemas"]["MirakurunService"];
+type Channel = components["schemas"]["MirakurunChannel"];
 type Program = components["schemas"]["MirakurunProgram"];
 type Schedule = components["schemas"]["WebRecordingSchedule"];
 
@@ -66,6 +68,59 @@ export const sampleServices: Service[] = [
     hasLogoData: false,
   },
 ];
+
+/**
+ * sampleServices をチャンネル単位に束ねた `/channels` 相当のフィクスチャ。
+ * `channel` がキーワード録画ルールの保存値 (MirakurunChannel.channel)。
+ */
+export const sampleChannels: Channel[] = [
+  {
+    channel: "27",
+    name: "NHK総合",
+    type: "GR",
+    services: [
+      { id: 3273601024, name: "NHK総合", networkId: 32736, serviceId: 1024 },
+    ],
+  },
+  {
+    channel: "26",
+    name: "Eテレ",
+    type: "GR",
+    services: [
+      { id: 3273701032, name: "Eテレ", networkId: 32737, serviceId: 1032 },
+    ],
+  },
+  {
+    channel: "25",
+    name: "日テレ",
+    type: "GR",
+    services: [
+      { id: 3274001040, name: "日テレ", networkId: 32740, serviceId: 1040 },
+    ],
+  },
+  {
+    channel: "24",
+    name: "テレビ朝日",
+    type: "GR",
+    services: [
+      { id: 3274101048, name: "テレビ朝日", networkId: 32741, serviceId: 1048 },
+    ],
+  },
+  {
+    channel: "BS15_0",
+    name: "BS NHK",
+    type: "BS",
+    services: [
+      { id: 4100101000, name: "BS NHK", networkId: 4, serviceId: 101 },
+    ],
+  },
+];
+
+/** sampleChannels を ChannelGroup に解決したもの (コンポーネントが消費する形)。 */
+export const sampleChannelGroups: ChannelGroup[] = buildChannelGroups(
+  sampleChannels,
+  sampleServices,
+);
 
 function makeProgram(
   partial: Partial<Program> & {

--- a/client/lib/keyword-preview.test.ts
+++ b/client/lib/keyword-preview.test.ts
@@ -63,13 +63,13 @@ describe("buildUpcoming", () => {
     expect(upcoming.map((e) => e.program.id)).toEqual([3, 2, 1]);
   });
 
-  it("service と target (serviceId / genres lv1) を解決する", () => {
+  it("service と target (channelId / genres lv1) を解決する", () => {
     const [entry] = buildUpcoming([program({ id: 1 })], services, now);
     expect(entry.service?.name).toBe("テレビA");
     expect(entry.target).toEqual({
       name: "番組",
       startAt: now + HOUR,
-      serviceId: 3273601024,
+      channelId: "27",
       genres: [0],
     });
   });

--- a/client/lib/keyword-preview.ts
+++ b/client/lib/keyword-preview.ts
@@ -46,7 +46,7 @@ export function buildUpcoming(
         target: {
           name: program.name,
           startAt: program.startAt,
-          serviceId: service?.id,
+          channelId: service?.channel.channel,
           genres: (program.genres ?? []).map((g) => g.lv1),
         },
       };

--- a/client/lib/service.ts
+++ b/client/lib/service.ts
@@ -3,6 +3,7 @@ import { t } from "../locales/i18n.ts";
 
 type Service = components["schemas"]["MirakurunService"];
 type Program = components["schemas"]["MirakurunProgram"];
+type Channel = components["schemas"]["MirakurunChannel"];
 
 /** 番組の属するサービス (channel) を networkId / serviceId で引く。 */
 export function serviceOfProgram(
@@ -18,6 +19,48 @@ export function serviceOfProgram(
 
 /** 放送波（channel type）の識別子。mirakc API の ChannelType を再エクスポートする。 */
 export type ChannelType = components["schemas"]["ChannelType"];
+
+/**
+ * キーワード録画のチャンネル選択・表示で扱う 1 チャンネル。`id` は
+ * `MirakurunChannel.channel`、ルールの保存値かつ番組との一致判定キーになる。
+ * `services` は配下のフルサービス (バッジの番号・色に必要)。
+ */
+export type ChannelGroup = {
+  /** チャンネル id (MirakurunChannel.channel)。 */
+  id: string;
+  /** 放送波。 */
+  type: ChannelType;
+  /** 放送局名 (MirakurunChannel.name)。 */
+  name: string;
+  /** 配下のサービス。横断録画の対象でありバッジ表示の素。 */
+  services: Service[];
+};
+
+/**
+ * `/channels` (MirakurunChannel[]) を、配下サービスをフル Service に解決した
+ * ChannelGroup[] にする。MirakurunChannel.services は番号・色の導出に必要な
+ * remoteControlKeyId 等を持たないため、`/services` と (networkId, serviceId)
+ * で突き合わせてフル Service に置き換える。解決できないサービスは除く。
+ */
+export function buildChannelGroups(
+  channels: Channel[],
+  services: Service[],
+): ChannelGroup[] {
+  const byKey = new Map(
+    services.map((service) => [
+      `${service.networkId}:${service.serviceId}`,
+      service,
+    ]),
+  );
+  return channels.map((channel) => ({
+    id: channel.channel,
+    type: channel.type,
+    name: channel.name,
+    services: channel.services
+      .map((s) => byKey.get(`${s.networkId}:${s.serviceId}`))
+      .filter((service): service is Service => service !== undefined),
+  }));
+}
 
 /**
  * 番組表 / 視聴ページのタブで扱う channel type。`channel.type` でサービスを束ねる。

--- a/client/routes/settings/keywords.tsx
+++ b/client/routes/settings/keywords.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Outlet, useNavigate } from "@tanstack/react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { $api } from "../../lib/api/client.ts";
 import {
   fetchKeywordRules,
@@ -8,6 +8,7 @@ import {
   removeKeywordRule,
   updateKeywordRule,
 } from "../../lib/api/keyword-rules.ts";
+import { buildChannelGroups } from "../../lib/service.ts";
 import { useNow } from "../../hooks/use-now.ts";
 import { t } from "../../locales/i18n.ts";
 import LoadingTemplate from "../../components/templates/Loading.tsx";
@@ -40,7 +41,14 @@ function KeywordRulesPage() {
     queryFn: () => fetchKeywordRules(),
   });
   const services = $api.useQuery("get", "/services");
+  const channels = $api.useQuery("get", "/channels");
   const programs = $api.useQuery("get", "/programs");
+
+  // 条件チップは channel 単位で表示する。配下サービスはバッジ用にフル解決する。
+  const channelGroups = useMemo(
+    () => buildChannelGroups(channels.data ?? [], services.data ?? []),
+    [channels.data, services.data],
+  );
 
   const invalidate = () =>
     queryClient.invalidateQueries({ queryKey: ["keyword-rules"] });
@@ -61,7 +69,10 @@ function KeywordRulesPage() {
     onSuccess: invalidate,
   });
 
-  if (rules.isPending || services.isPending || programs.isPending) {
+  if (
+    rules.isPending || services.isPending || channels.isPending ||
+    programs.isPending
+  ) {
     return <LoadingTemplate label={t("keyword.loading")} />;
   }
 
@@ -69,6 +80,7 @@ function KeywordRulesPage() {
     <KeywordRulesTemplate
       rules={rules.data ?? []}
       services={services.data ?? []}
+      channels={channelGroups}
       programs={programs.data ?? []}
       currentEpochMs={currentEpochMs}
       busy={toggle.isPending || remove.isPending}

--- a/client/routes/settings/keywords/$ruleId.tsx
+++ b/client/routes/settings/keywords/$ruleId.tsx
@@ -8,6 +8,7 @@ import {
   updateKeywordRule,
 } from "../../../lib/api/keyword-rules.ts";
 import { buildUpcoming } from "../../../lib/keyword-preview.ts";
+import { buildChannelGroups } from "../../../lib/service.ts";
 import { useNow } from "../../../hooks/use-now.ts";
 import RuleFormModal from "../../../components/organisms/KeywordRules/RuleFormModal.tsx";
 
@@ -27,7 +28,13 @@ function EditKeywordRuleModal() {
     queryFn: () => fetchKeywordRules(),
   });
   const services = $api.useQuery("get", "/services");
+  const channels = $api.useQuery("get", "/channels");
   const programs = $api.useQuery("get", "/programs");
+
+  const channelGroups = useMemo(
+    () => buildChannelGroups(channels.data ?? [], services.data ?? []),
+    [channels.data, services.data],
+  );
 
   const rule = (rules.data ?? []).find((r) => r.id === ruleId);
 
@@ -62,7 +69,7 @@ function EditKeywordRuleModal() {
     <RuleFormModal
       open
       initial={rule}
-      services={services.data ?? []}
+      channels={channelGroups}
       upcoming={upcoming}
       busy={update.isPending}
       onSave={(input) => update.mutate(input)}

--- a/client/routes/settings/keywords/new.tsx
+++ b/client/routes/settings/keywords/new.tsx
@@ -7,6 +7,7 @@ import {
   type KeywordRuleInput,
 } from "../../../lib/api/keyword-rules.ts";
 import { buildUpcoming } from "../../../lib/keyword-preview.ts";
+import { buildChannelGroups } from "../../../lib/service.ts";
 import { useNow } from "../../../hooks/use-now.ts";
 import RuleFormModal from "../../../components/organisms/KeywordRules/RuleFormModal.tsx";
 
@@ -21,7 +22,13 @@ function NewKeywordRuleModal() {
 
   const currentEpochMs = useNow(60_000);
   const services = $api.useQuery("get", "/services");
+  const channels = $api.useQuery("get", "/channels");
   const programs = $api.useQuery("get", "/programs");
+
+  const channelGroups = useMemo(
+    () => buildChannelGroups(channels.data ?? [], services.data ?? []),
+    [channels.data, services.data],
+  );
 
   const close = () => navigate({ to: "/settings/keywords" });
 
@@ -42,7 +49,7 @@ function NewKeywordRuleModal() {
   return (
     <RuleFormModal
       open
-      services={services.data ?? []}
+      channels={channelGroups}
       upcoming={upcoming}
       busy={add.isPending}
       onSave={(input) => add.mutate(input)}

--- a/docs/api/components/schemas/KeywordRule.yaml
+++ b/docs/api/components/schemas/KeywordRule.yaml
@@ -5,7 +5,7 @@ description:
 required:
   - id
   - keyword
-  - serviceIds
+  - channels
   - genres
   - enabled
   - createdAt
@@ -28,12 +28,11 @@ properties:
     format: date-time
     description: 期間の終了日時。RFC 3339 形式でタイムゾーンを含み、終了日の 23:59:59 を表す。未指定は無制限。
     example: "2026-01-31T23:59:59+09:00"
-  serviceIds:
+  channels:
     type: array
     items:
-      type: integer
-      format: int64
-    description: 対象サービスの Mirakurun service id の配列。空配列は全チャンネルを表す。
+      type: string
+    description: 対象チャンネルの Mirakurun channel (MirakurunChannel.channel) の配列。空配列は全チャンネルを表す。チャンネル配下の全サービスを横断して対象にする。
   genres:
     type: array
     items:

--- a/docs/api/components/schemas/KeywordRuleInput.yaml
+++ b/docs/api/components/schemas/KeywordRuleInput.yaml
@@ -19,13 +19,12 @@ properties:
     format: date-time
     description: 期間の終了日時。RFC 3339 形式でタイムゾーンを含み、終了日の 23:59:59 を表す。未指定は無制限。
     example: "2026-01-31T23:59:59+09:00"
-  serviceIds:
+  channels:
     type: array
     items:
-      type: integer
-      format: int64
+      type: string
     default: []
-    description: 対象サービスの Mirakurun service id の配列。空配列または未指定は全チャンネルを表す。
+    description: 対象チャンネルの Mirakurun channel (MirakurunChannel.channel) の配列。空配列または未指定は全チャンネルを表す。チャンネル配下の全サービスを横断して対象にする。
   genres:
     type: array
     items:

--- a/docs/api/examples/KeywordRule.yaml
+++ b/docs/api/examples/KeywordRule.yaml
@@ -2,8 +2,8 @@ id: 0f9a1b2c-3d4e-5f60-7182-93a4b5c6d7e8
 keyword: 大相撲
 from: "2026-01-01"
 to: "2026-01-31"
-serviceIds:
-  - 3273601024
+channels:
+  - "27"
 genres:
   - 1
 enabled: true

--- a/docs/api/examples/KeywordRuleInput.yaml
+++ b/docs/api/examples/KeywordRuleInput.yaml
@@ -1,8 +1,8 @@
 keyword: 大相撲
 from: "2026-01-01"
 to: "2026-01-31"
-serviceIds:
-  - 3273601024
+channels:
+  - "27"
 genres:
   - 1
 enabled: true

--- a/docs/api/paths/keyword-rules.yaml
+++ b/docs/api/paths/keyword-rules.yaml
@@ -20,7 +20,7 @@ get:
                 - $ref: ../examples/KeywordRule.yaml
                 - id: 1a2b3c4d-5e6f-7081-92a3-b4c5d6e7f809
                   keyword: 紅白歌合戦
-                  serviceIds: []
+                  channels: []
                   genres: []
                   enabled: false
                   createdAt: 1767139200000

--- a/server/lib/api/internal-schemas.ts
+++ b/server/lib/api/internal-schemas.ts
@@ -12,7 +12,7 @@ export const internalSchemas = {
     "required": [
       "id",
       "keyword",
-      "serviceIds",
+      "channels",
       "genres",
       "enabled",
       "createdAt"
@@ -40,13 +40,12 @@ export const internalSchemas = {
         "description": "期間の終了日時。RFC 3339 形式でタイムゾーンを含み、終了日の 23:59:59 を表す。未指定は無制限。",
         "example": "2026-01-31T23:59:59+09:00"
       },
-      "serviceIds": {
+      "channels": {
         "type": "array",
         "items": {
-          "type": "integer",
-          "format": "int64"
+          "type": "string"
         },
-        "description": "対象サービスの Mirakurun service id の配列。空配列は全チャンネルを表す。"
+        "description": "対象チャンネルの Mirakurun channel (MirakurunChannel.channel) の配列。空配列は全チャンネルを表す。チャンネル配下の全サービスを横断して対象にする。"
       },
       "genres": {
         "type": "array",
@@ -93,14 +92,13 @@ export const internalSchemas = {
         "description": "期間の終了日時。RFC 3339 形式でタイムゾーンを含み、終了日の 23:59:59 を表す。未指定は無制限。",
         "example": "2026-01-31T23:59:59+09:00"
       },
-      "serviceIds": {
+      "channels": {
         "type": "array",
         "items": {
-          "type": "integer",
-          "format": "int64"
+          "type": "string"
         },
         "default": [],
-        "description": "対象サービスの Mirakurun service id の配列。空配列または未指定は全チャンネルを表す。"
+        "description": "対象チャンネルの Mirakurun channel (MirakurunChannel.channel) の配列。空配列または未指定は全チャンネルを表す。チャンネル配下の全サービスを横断して対象にする。"
       },
       "genres": {
         "type": "array",

--- a/server/lib/keyword-recorder.test.ts
+++ b/server/lib/keyword-recorder.test.ts
@@ -11,8 +11,28 @@ import type { KeywordRule } from "./keyword-rules.ts";
 const startAt = Date.UTC(2026, 0, 1, 18, 4, 5);
 
 const services = [
-  { id: 3273601024, networkId: 32736, serviceId: 1024, name: "テレビA" },
-  { id: 3273701032, networkId: 32737, serviceId: 1032, name: "テレビB" },
+  // テレビA と テレビA-2 は同じ物理チャンネル "27" に相乗りしている。
+  {
+    id: 3273601024,
+    networkId: 32736,
+    serviceId: 1024,
+    name: "テレビA",
+    channel: { channel: "27", type: "GR" },
+  },
+  {
+    id: 3273601025,
+    networkId: 32736,
+    serviceId: 1025,
+    name: "テレビA-2",
+    channel: { channel: "27", type: "GR" },
+  },
+  {
+    id: 3273701032,
+    networkId: 32737,
+    serviceId: 1032,
+    name: "テレビB",
+    channel: { channel: "25", type: "GR" },
+  },
 ];
 
 function program(overrides: Record<string, unknown> = {}) {
@@ -33,7 +53,7 @@ function rule(overrides: Partial<KeywordRule> = {}): KeywordRule {
   return {
     id: "rule-1",
     keyword: "ニュース",
-    serviceIds: [],
+    channels: [],
     genres: [],
     enabled: true,
     createdAt: 0,
@@ -148,20 +168,40 @@ Deno.test("runKeywordRecording: 一致した将来番組を予約し通知する
   );
 });
 
-Deno.test("runKeywordRecording: チャンネル条件は service id を解決して判定する", async () => {
-  // 番組は networkId 32736 / serviceId 1024 → Mirakurun id 3273601024。
+Deno.test("runKeywordRecording: チャンネル条件は service の channel を解決して判定する", async () => {
+  // 番組は networkId 32736 / serviceId 1024 → channel "27"。
   const { calls, fetchFn } = fakeMirakc({ programs: [program()] });
 
   const matched = await runKeywordRecording(
-    deps([rule({ serviceIds: [3273601024] })], fetchFn),
+    deps([rule({ channels: ["27"] })], fetchFn),
   );
   assertEquals(matched.registered.length, 1);
 
   const { fetchFn: fetchFn2 } = fakeMirakc({ programs: [program()] });
   const unmatched = await runKeywordRecording(
-    deps([rule({ serviceIds: [3273701032] })], fetchFn2),
+    deps([rule({ channels: ["25"] })], fetchFn2),
   );
   assertEquals(unmatched.registered, []);
+  assertEquals(calls.filter((c) => c.method === "POST").length, 1);
+});
+
+Deno.test("runKeywordRecording: チャンネル条件は配下サービスを横断する", async () => {
+  // serviceId 1025 (テレビA-2) も channel "27" に属する。
+  // channels ["27"] のルールは相乗りサービスの番組も対象にする。
+  const onSubService = program({
+    id: 327360102506471,
+    serviceId: 1025,
+    name: "ニュース速報",
+  });
+  const { calls, fetchFn } = fakeMirakc({ programs: [onSubService] });
+
+  const result = await runKeywordRecording(
+    deps([rule({ channels: ["27"] })], fetchFn),
+  );
+
+  assertEquals(result.registered, [
+    { programId: onSubService.id, keyword: "ニュース" },
+  ]);
   assertEquals(calls.filter((c) => c.method === "POST").length, 1);
 });
 

--- a/server/lib/keyword-recorder.ts
+++ b/server/lib/keyword-recorder.ts
@@ -35,12 +35,14 @@ export type ProgramLike = {
   genres?: { lv1: number }[] | null;
 };
 
-/** service id 解決・チャンネル名表示に使うサービス情報のサブセット。 */
+/** チャンネル解決・チャンネル名表示に使うサービス情報のサブセット。 */
 type ServiceLike = {
-  id: number;
   networkId: number;
   serviceId: number;
   name: string;
+
+  /** 番組の属するチャンネル。channel.channel をルールの一致判定に使う。 */
+  channel: { channel: string };
 };
 
 export type KeywordRecorderDeps = {
@@ -111,7 +113,7 @@ export async function runKeywordRecording(
     fetchJson<ScheduleLike[]>(fetchFn, `${apiUrl}/recording/schedules`),
   ]);
   const scheduledIds = new Set(schedules.map((s) => s.program.id));
-  // (networkId, serviceId) → サービス (Mirakurun の複合 id とチャンネル名)。
+  // (networkId, serviceId) → サービス (チャンネル解決とチャンネル名表示に使う)。
   const serviceOf = new Map(
     services.map((s) => [`${s.networkId}:${s.serviceId}`, s]),
   );
@@ -125,7 +127,7 @@ export async function runKeywordRecording(
     const target = {
       name: program.name,
       startAt: program.startAt,
-      serviceId: service?.id,
+      channelId: service?.channel.channel,
       genres: (program.genres ?? []).map((g) => g.lv1),
     };
     const rule = rules.find((r) => matchesKeywordRule(r, target));

--- a/server/lib/keyword-rules.test.ts
+++ b/server/lib/keyword-rules.test.ts
@@ -11,7 +11,7 @@ function rule(overrides: Partial<KeywordRule> = {}): KeywordRule {
     // id は uuid (生成スキーマの format: uuid を満たす実データ相当)。
     id: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
     keyword: "ニュース",
-    serviceIds: [],
+    channels: [],
     genres: [],
     enabled: true,
     createdAt: 0,
@@ -26,7 +26,7 @@ function target(overrides: Record<string, unknown> = {}) {
   return {
     name: "ニュースウォッチ",
     startAt,
-    serviceId: 3273601024,
+    channelId: "27",
     genres: [0, 3],
     ...overrides,
   };
@@ -88,19 +88,19 @@ Deno.test("matchesKeywordRule: 期間は from/to の RFC 3339 日時の範囲で
   );
 });
 
-Deno.test("matchesKeywordRule: serviceIds 空は全チャンネル、指定時は一致のみ", () => {
+Deno.test("matchesKeywordRule: channels 空は全チャンネル、指定時は一致のみ", () => {
   assertEquals(
-    matchesKeywordRule(rule({ serviceIds: [3273601024] }), target()),
+    matchesKeywordRule(rule({ channels: ["27"] }), target()),
     true,
   );
   assertEquals(
-    matchesKeywordRule(rule({ serviceIds: [999] }), target()),
+    matchesKeywordRule(rule({ channels: ["99"] }), target()),
     false,
   );
   assertEquals(
     matchesKeywordRule(
-      rule({ serviceIds: [999] }),
-      target({ serviceId: undefined }),
+      rule({ channels: ["99"] }),
+      target({ channelId: undefined }),
     ),
     false,
   );
@@ -123,7 +123,7 @@ Deno.test("parseKeywordRuleInput: 正常系は trim と既定値を適用する"
       keyword: "サッカー",
       from: undefined,
       to: undefined,
-      serviceIds: [],
+      channels: [],
       genres: [],
       enabled: true,
     },
@@ -135,7 +135,7 @@ Deno.test("parseKeywordRuleInput: 全項目指定", () => {
     keyword: "ドラマ",
     from: "2026-01-01T00:00:00+09:00",
     to: "2026-01-31T23:59:59+09:00",
-    serviceIds: [3273601024, 3273701032],
+    channels: ["27", "25"],
     genres: [3, 7],
     enabled: false,
   });
@@ -143,7 +143,7 @@ Deno.test("parseKeywordRuleInput: 全項目指定", () => {
   if (result.ok) {
     assertEquals(result.input.from, "2026-01-01T00:00:00+09:00");
     assertEquals(result.input.to, "2026-01-31T23:59:59+09:00");
-    assertEquals(result.input.serviceIds, [3273601024, 3273701032]);
+    assertEquals(result.input.channels, ["27", "25"]);
     assertEquals(result.input.genres, [3, 7]);
     assertEquals(result.input.enabled, false);
   }
@@ -166,7 +166,9 @@ Deno.test("parseKeywordRuleInput: 不正値は ok:false", () => {
       from: "2026-01-02T00:00:00+09:00",
       to: "2026-01-01T23:59:59+09:00",
     },
-    { keyword: "x", serviceIds: ["a"] },
+    // channels は文字列配列。数値要素は不正。
+    { keyword: "x", channels: [1] },
+    { keyword: "x", channels: "x" },
     { keyword: "x", genres: [16] },
     { keyword: "x", genres: [-1] },
     { keyword: "x", enabled: "yes" },
@@ -212,11 +214,11 @@ Deno.test("isKeywordRule: 壊れた値は除外する", () => {
     123,
     {},
     // 必須キー (id / createdAt) 欠落。
-    { keyword: "x", serviceIds: [], genres: [], enabled: true },
+    { keyword: "x", channels: [], genres: [], enabled: true },
     // 型違い。
     { ...rule(), createdAt: "x" },
     { ...rule(), enabled: "yes" },
-    { ...rule(), serviceIds: "x" },
+    { ...rule(), channels: "x" },
     // 範囲外ジャンル (minimum / maximum はアサーションとして効く)。
     { ...rule(), genres: [16] },
     { ...rule(), genres: [-1] },

--- a/server/lib/keyword-rules.ts
+++ b/server/lib/keyword-rules.ts
@@ -17,7 +17,7 @@ import {
 /**
  * キーワード自動録画のルール。docs/api の OpenAPI から生成した component
  * schema (internal-schemas.ts) を型の単一ソースとする。
- * (id / keyword / serviceIds / genres / enabled / createdAt を持ち、
+ * (id / keyword / channels / genres / enabled / createdAt を持ち、
  * from / to は任意。)
  */
 export type KeywordRule = FromSchema<typeof internalSchemas["KeywordRule"]>;
@@ -32,8 +32,8 @@ export type KeywordRuleTarget = {
   /** 開始時刻 (epoch ms)。期間条件のローカル日付判定に使う。 */
   startAt: number;
 
-  /** Mirakurun service id (networkId とのペアから解決した複合 id)。 */
-  serviceId?: number;
+  /** 番組が属するチャンネル (MirakurunChannel.channel)。サービスから解決する。 */
+  channelId?: string;
 
   /** ジャンルの ARIB lv1 コード一覧。 */
   genres: number[];
@@ -66,7 +66,7 @@ export type ParseResult =
 
 /**
  * リクエストボディが KeywordRuleInput スキーマ (required 緩和済み) に適合するか
- * を判定する型ガード。適合すれば serviceIds / genres / enabled / from / to は
+ * を判定する型ガード。適合すれば channels / genres / enabled / from / to は
  * 任意 (未指定は parse 側で既定値補完) の型に narrow される。
  */
 function isKeywordRuleInputBody(
@@ -118,7 +118,7 @@ export function parseKeywordRuleInput(value: unknown): ParseResult {
       keyword,
       from,
       to,
-      serviceIds: value.serviceIds ?? [],
+      channels: value.channels ?? [],
       genres: value.genres ?? [],
       enabled: value.enabled ?? true,
     },
@@ -132,10 +132,12 @@ export function parseKeywordRuleInput(value: unknown): ParseResult {
  * - キーワード: 番組名の部分一致 (大文字小文字無視)。名前なしは不一致
  * - 期間: 開始時刻 (瞬間) が from / to の RFC 3339 日時の範囲内 (両端含む)。
  *   from / to はタイムゾーン付きの絶対時刻なので瞬間どうしで比較する
- * - serviceIds / genres: 空は無条件、指定時は一致 (genres は交差) を要求
+ * - channels / genres: 空は無条件、指定時は一致 (genres は交差) を要求。
+ *   channels は番組の属するチャンネル (MirakurunChannel.channel) で判定するため、
+ *   チャンネル配下の全サービスを横断して対象になる
  */
 export function matchesKeywordRule(
-  rule: Pick<KeywordRule, "keyword" | "from" | "to" | "serviceIds" | "genres">,
+  rule: Pick<KeywordRule, "keyword" | "from" | "to" | "channels" | "genres">,
   target: KeywordRuleTarget,
 ): boolean {
   if (!target.name?.toLowerCase().includes(rule.keyword.toLowerCase())) {
@@ -155,10 +157,10 @@ export function matchesKeywordRule(
     }
   }
 
-  if (rule.serviceIds.length > 0) {
+  if (rule.channels.length > 0) {
     if (
-      target.serviceId === undefined ||
-      !rule.serviceIds.includes(target.serviceId)
+      target.channelId === undefined ||
+      !rule.channels.includes(target.channelId)
     ) {
       return false;
     }

--- a/server/routes/keyword-rules.test.ts
+++ b/server/routes/keyword-rules.test.ts
@@ -39,7 +39,7 @@ function ruleOf(overrides: Partial<KeywordRule> = {}): KeywordRule {
   return {
     id: "a",
     keyword: "ニュース",
-    serviceIds: [],
+    channels: [],
     genres: [],
     enabled: true,
     createdAt: 1,
@@ -66,7 +66,7 @@ Deno.test("POST /: ルールを追加して 201 を返す", async () => {
     body: JSON.stringify({
       keyword: " ドキュメンタリー ",
       from: "2026-01-01T00:00:00+09:00",
-      serviceIds: [3273601024],
+      channels: ["27"],
       genres: [8],
     }),
   });
@@ -74,7 +74,7 @@ Deno.test("POST /: ルールを追加して 201 を返す", async () => {
   const body = await res.json();
   assertEquals(body.keyword, "ドキュメンタリー");
   assertEquals(body.from, "2026-01-01T00:00:00+09:00");
-  assertEquals(body.serviceIds, [3273601024]);
+  assertEquals(body.channels, ["27"]);
   assertEquals(body.genres, [8]);
   assertEquals(body.enabled, true);
   assertEquals(store.rules.length, 1);

--- a/server/store/keyword-rules.test.ts
+++ b/server/store/keyword-rules.test.ts
@@ -11,7 +11,7 @@ function input(overrides: Partial<KeywordRuleInput> = {}): KeywordRuleInput {
     keyword: "ニュース",
     from: undefined,
     to: undefined,
-    serviceIds: [],
+    channels: [],
     genres: [],
     enabled: true,
     ...overrides,
@@ -53,7 +53,7 @@ Deno.test("add: 条件付きルールの全項目を保存する", async () => {
         keyword: "ドラマ",
         from: "2026-01-01T00:00:00+09:00",
         to: "2026-01-31T23:59:59+09:00",
-        serviceIds: [3273601024],
+        channels: ["27"],
         genres: [3],
         enabled: false,
       }),
@@ -61,7 +61,7 @@ Deno.test("add: 条件付きルールの全項目を保存する", async () => {
     );
     assertEquals((await store.list())[0], rule);
     assertEquals(rule.from, "2026-01-01T00:00:00+09:00");
-    assertEquals(rule.serviceIds, [3273601024]);
+    assertEquals(rule.channels, ["27"]);
     assertEquals(rule.genres, [3]);
     assertEquals(rule.enabled, false);
   });
@@ -96,4 +96,29 @@ Deno.test("remove: 削除で true、無ければ false", async () => {
     assertEquals(await store.list(), []);
     assertEquals(await store.remove(rule.id), false);
   });
+});
+
+Deno.test("list: 旧 serviceIds 形式は channels:[] にフォールバックする", async () => {
+  const kv = createKv(":memory:");
+  try {
+    const store = createKeywordRuleStore(kv);
+    // チャンネル条件を service 単位から channel 単位へ移行する前の保存形。
+    // service→channel の解決はここでは出来ないため全チャンネル扱いに均す。
+    await kv.set(["settings", "keyword-rules", "legacy-1"], {
+      id: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+      keyword: "旧ルール",
+      serviceIds: [3273601024],
+      genres: [],
+      enabled: true,
+      createdAt: 0,
+    });
+
+    const rules = await store.list();
+    assertEquals(rules.length, 1);
+    assertEquals(rules[0].channels, []);
+    // 旧キーは均しで除かれる。
+    assertEquals("serviceIds" in rules[0], false);
+  } finally {
+    await kv.close();
+  }
 });

--- a/server/store/keyword-rules.ts
+++ b/server/store/keyword-rules.ts
@@ -15,10 +15,26 @@ import { type CollectionStore, collectionStore, type Kv } from "./kv.ts";
 
 export type KeywordRuleStore = CollectionStore<KeywordRule, KeywordRuleInput>;
 
+/**
+ * 読み戻したルールを現行スキーマへ均す。チャンネル条件を service 単位
+ * (`serviceIds`) からチャンネル単位 (`channels`) へ移行した際の後方互換:
+ * 旧 `serviceIds` は service→channel の解決に mirakc データが要るためここでは
+ * 変換できない。旧ルールは `channels: []` (= 全チャンネル) にフォールバックし、
+ * クラッシュさせずに残す (絞り込みは失われるので必要なら再登録)。
+ */
+function normalizeStoredKeywordRule(value: unknown): unknown {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return value;
+  }
+  const { serviceIds: _legacy, ...rest } = value as Record<string, unknown>;
+  return "channels" in rest ? rest : { ...rest, channels: [] };
+}
+
 /** キーワードルールのストア。Kv は main.ts で生成したものを共有する。 */
 export function createKeywordRuleStore(kv: Kv): KeywordRuleStore {
   return collectionStore<KeywordRuleInput, KeywordRule>(kv, {
     prefix: ["settings", "keyword-rules"],
     isValid: isKeywordRule,
+    normalize: normalizeStoredKeywordRule,
   });
 }

--- a/server/store/kv.ts
+++ b/server/store/kv.ts
@@ -108,7 +108,9 @@ export type CollectionStore<T, Input> = {
 
 /**
  * コレクション型ストアを生成する。レコードは `{ ...input, id, createdAt }` の
- * 形で保存し、読み戻しは isValid で検証して壊れた値・旧形状を除く。
+ * 形で保存し、読み戻しは normalize → isValid の順で旧形状の補完と検証を行い、
+ * 壊れた値を除く。normalize は singletonStore と対称で、KV に残る旧スキーマを
+ * 現行スキーマへ均すための任意フック (省略時は素通し)。
  */
 export function collectionStore<
   Input,
@@ -120,11 +122,14 @@ export function collectionStore<
     prefix: Deno.KvKey;
     /** 読み戻した値が T か判定する型ガード。 */
     isValid: (value: unknown) => value is T;
+    /** 読み戻した値を現行スキーマへ均す (旧形状の補完)。省略時は素通し。 */
+    normalize?: (value: unknown) => unknown;
     /** 並び順。既定は createdAt 降順 → id。 */
     sort?: (a: T, b: T) => number;
   },
 ): CollectionStore<T, Input> {
   const { prefix, isValid } = cfg;
+  const normalize = cfg.normalize ?? ((value: unknown) => value);
   const sort = cfg.sort ??
     ((a: T, b: T) => b.createdAt - a.createdAt || a.id.localeCompare(b.id));
   const keyOf = (id: string): Deno.KvKey => [...prefix, id];
@@ -132,7 +137,7 @@ export function collectionStore<
   return {
     async list() {
       const values = await kv.listValues(prefix);
-      return values.filter(isValid).sort(sort);
+      return values.map(normalize).filter(isValid).sort(sort);
     },
     async add(input, now = Date.now()) {
       const record = { ...input, id: crypto.randomUUID(), createdAt: now } as T;
@@ -140,7 +145,7 @@ export function collectionStore<
       return record;
     },
     async update(id, input) {
-      const current = await kv.get(keyOf(id));
+      const current = normalize(await kv.get(keyOf(id)));
       if (!isValid(current)) {
         return null;
       }


### PR DESCRIPTION
## 概要

キーワード自動録画のチャンネル設定を `Channel.services` 単位（複合 service id の配列 `serviceIds`）から **Channel 単位**（`MirakurunChannel.channel` の配列 `channels`）へ移行した。録画対象もチャンネル配下の全サービスを横断する。

物理 1 チャンネルに相乗りする複数サービス（例: GR 物理 27ch の NHK総合1・2）が 1 つの選択肢に畳まれ、まとめて対象になる。

## 変更点

### 型の単一ソース（docs/api OpenAPI）
- `KeywordRule` / `KeywordRuleInput` の `serviceIds: int64[]` → `channels: string[]`。`deno task generate:internal` で `server/lib/api/internal-schemas.ts` を再生成し、client / server 双方の型が追従。

### マッチング（共有ロジック `server/lib/keyword-rules.ts`）
- `KeywordRuleTarget.serviceId` → `channelId?: string`。`matchesKeywordRule` は `rule.channels` に番組の `channelId` が含まれるかで判定。番組 → サービス → `service.channel.channel` で解決するため、同一チャンネルの複数サービスを自動で横断する。

### 録画ジョブ / プレビュー
- `keyword-recorder.ts`（server）・`keyword-preview.ts`（client）とも `target.channelId = service.channel.channel` を解決。server は `/services` のままで `/channels` 取得は不要。

### UI
- フォーム・カードの選択／表示単位をチャンネルに変更。route 3 本（`keywords` / `new` / `$ruleId`）が `/channels` を取得し、新設の `buildChannelGroups`（`client/lib/service.ts`）で `MirakurunChannel` を `/services` と突き合わせてフル `Service` に解決（バッジのリモコン番号・色を維持）。

### 既存データの移行
- `collectionStore` に任意の `normalize` フックを追加。旧 `serviceIds` 形式の保存値は読み戻し時に `channels: []`（全チャンネル）へフォールバックする。service → channel の解決に mirakc データが要るため自動変換はせず、絞り込みは失われる（必要なら再登録）。

## 検証

- `deno task check`（fmt / lint / 型、CI 相当）: pass
- `deno task test:server`: 94 passed（チャンネル横断・移行フォールバックのテストを追加）
- `deno task test:client`: 251 passed
- `deno task storybook:build` / `deno task build`: pass
- docs/api lint（redocly / textlint / fmt）: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)