### PR TITLE
fix: 設定画面の削除確認がマウス離脱で消える挙動を撤去

### DIFF
--- a/client/components/organisms/KeywordRules/RuleCard.tsx
+++ b/client/components/organisms/KeywordRules/RuleCard.tsx
@@ -116,7 +116,6 @@ export default function RuleCard(props: Props) {
   return (
     <div
       className={`${styles.card} ${rule.enabled ? "" : styles.off}`}
-      onMouseLeave={() => setConfirming(false)}
     >
       <ToggleSwitch
         checked={rule.enabled}

--- a/client/components/organisms/LiveComment/MappingCard.tsx
+++ b/client/components/organisms/LiveComment/MappingCard.tsx
@@ -52,7 +52,6 @@ export default function MappingCard(props: Props) {
   return (
     <div
       className={`${styles.card} ${mapping.enabled ? "" : styles.off}`}
-      onMouseLeave={() => setConfirming(false)}
     >
       <ToggleSwitch
         checked={mapping.enabled}


### PR DESCRIPTION
## 概要

設定画面系のカードで、削除確認 (「削除しますか?」) の表示中にカードからマウスが外れると確認が非表示になる挙動を撤去した。意図しない閉じ方なので削除する。

## 変更内容

- `client/components/organisms/KeywordRules/RuleCard.tsx`: カード要素の `onMouseLeave={() => setConfirming(false)}` を削除
- `client/components/organisms/LiveComment/MappingCard.tsx`: 同上

## 挙動の変化

- これまで: 削除確認の表示中にカードからマウスが外れると確認が消えていた
- これから: 削除確認は「削除実行」または「キャンセル」ボタンの明示操作でのみ閉じる

確認を閉じるキャンセルボタン (×, `confirmCancel`) は元々あるため、確認を閉じられなくなることはない。`DefaultsButton.tsx` にはこの `onMouseLeave` は無いため対象外。

## 確認

- `deno task check` (fmt / lint / 型) 通過
- `deno task test:client` 57 ファイル / 293 件 全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)