### PR TITLE
fix: ライブ視聴プレイヤーの再生/停止操作を無効化

### DIFF
--- a/client/components/organisms/Watch/Player.test.tsx
+++ b/client/components/organisms/Watch/Player.test.tsx
@@ -105,4 +105,13 @@ describe("WatchPlayer", () => {
     expect(onQualityChange).toHaveBeenCalledTimes(1);
     expect(onQualityChange).toHaveBeenCalledWith("480p");
   });
+
+  it("pause されても (メディアキー等) 即座に再生へ戻し停止させない", () => {
+    const { container } = render(<WatchPlayer {...baseProps()} />);
+    const video = container.querySelector("video");
+    expect(video).toBeTruthy();
+    const playSpy = vi.spyOn(video!, "play").mockResolvedValue(undefined);
+    fireEvent.pause(video!);
+    expect(playSpy).toHaveBeenCalled();
+  });
 });

--- a/client/components/organisms/Watch/Player.tsx
+++ b/client/components/organisms/Watch/Player.tsx
@@ -178,6 +178,34 @@ export default function WatchPlayer(props: Props) {
     };
   }, []);
 
+  // メディアキー / OS のメディア UI からの一時停止・停止を無効化する。
+  // 上の pause→再生 復帰だけでも停止は防げるが、ここで経路の元を断つことで
+  // メディアキー押下時に一瞬止まってから戻るブリップ自体を消す。
+  useEffect(() => {
+    if (!("mediaSession" in navigator)) {
+      return;
+    }
+    const ms = navigator.mediaSession;
+    const noop = () => {};
+    const actions: MediaSessionAction[] = ["pause", "stop"];
+    for (const action of actions) {
+      try {
+        ms.setActionHandler(action, noop);
+      } catch {
+        // 未対応のアクションは無視する (ブラウザ差異)。
+      }
+    }
+    return () => {
+      for (const action of actions) {
+        try {
+          ms.setActionHandler(action, null);
+        } catch {
+          // ignore
+        }
+      }
+    };
+  }, []);
+
   useEffect(() => {
     if (!props.streamUrl || !videoRef.current || !captionContainerRef.current) {
       return;
@@ -201,8 +229,21 @@ export default function WatchPlayer(props: Props) {
         setBuffering(true);
       }
     };
+    // ライブ配信は一時停止の概念が無く、再生/停止 UI も持たない。メディアキー /
+    // OS のメディア UI など経路を問わず pause された場合は即座に再生へ戻し、
+    // 「止められない」状態を保証する (データ待ちは waiting なので干渉しない)。
+    const handlePause = () => {
+      if (destroyed) {
+        return;
+      }
+      const r = video.play();
+      if (r && typeof r.catch === "function") {
+        r.catch(() => {});
+      }
+    };
     video.addEventListener("playing", handlePlaying);
     video.addEventListener("waiting", handleWaiting);
+    video.addEventListener("pause", handlePause);
 
     const loadMpegts = props.loadMpegts ?? (() => import("mpegts.js"));
     const loadAribb24 = props.loadAribb24 ?? (() => import("aribb24.js"));
@@ -336,6 +377,7 @@ export default function WatchPlayer(props: Props) {
 
       video.removeEventListener("playing", handlePlaying);
       video.removeEventListener("waiting", handleWaiting);
+      video.removeEventListener("pause", handlePause);
 
       if (aribb24Ref.current) {
         try {


### PR DESCRIPTION
## 概要

ライブ視聴プレイヤーには再生/停止ボタンを置いていないが、メディアキーや OS のメディア UI 経由で一時停止できてしまっていた。ライブ配信に一時停止の概念は無いため、この操作経路を無効化する。

## 原因

`<video>` 要素に `controls` を付けていないため、要素自身のキーボードショートカット（Space 等）は効かない。残っていた停止経路はメディアキー → ブラウザの Media Session のデフォルト pause/play ハンドラ。

## 変更

`client/components/organisms/Watch/Player.tsx` に二段の防御を入れた。

1. **pause イベント即時復帰（catch-all）**: 主 effect 内に `pause` リスナーを追加し、経路を問わず止められたら即 `video.play()` で再生へ戻す。`destroyed` ガード付き、cleanup で除去（mpegts の `player.pause()` が teardown で走る前にリスナーを外すため競合しない）。
2. **Media Session 無効化（元断ち）**: `navigator.mediaSession` の `pause` / `stop` アクションを no-op ハンドラに差し替え、メディアキー押下時に一瞬止まってから戻るブリップ自体を消す。feature detection + try/catch でブラウザ差異を吸収し、unmount で `null` に戻す。

明示停止は `pause`、データ待ちは `waiting` と別イベントのため、pause 復帰はバッファリング表示と干渉しない。

## テスト

- TDD（Red→Green）: `pause` 発火で `video.play()` が呼ばれることを検証するテストを追加。
- `deno task test:client`: 57 ファイル / 294 件パス。
- `deno task check`（型）/ `deno lint`: パス。

## 動作確認

- [ ] 実機ブラウザでメディアキー操作時に再生が止まらないことを目視確認（自動テストはイベント発火までの検証）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
