### PR TITLE
fix: 番組表スクロール時に番組内容を sticky 追従させる

### DIFF
--- a/client/components/organisms/Program/Table.module.css
+++ b/client/components/organisms/Program/Table.module.css
@@ -99,7 +99,13 @@
   border: 1px solid transparent;
   border-left: 4px solid transparent;
   border-radius: 0.4rem;
-  overflow: hidden;
+  /*
+   * overflow: hidden ではなく clip。hidden はスクロールコンテナを生成し、
+   * 中の .programContent の sticky が外側 (.scroll) 基準で効かなくなる。
+   * clip はスクロールコンテナを作らずクリップだけ行うため、sticky 追従を保ちつつ
+   * 短い番組の内容はみ出しを抑えられる。
+   */
+  overflow: clip;
   cursor: pointer;
   transition: box-shadow 0.12s, filter 0.12s;
 
@@ -125,6 +131,17 @@
   &[data-mark="finished"] {
     box-shadow: inset 0 0 0 2px var(--color-accent);
   }
+}
+
+/*
+ * セル内容。長尺番組をスクロールしてもタイトルが見えるよう sticky で追従させる。
+ * top は sticky なヘッダ行 (.serviceHeader / .timeNum, 高さ 6rem) の直下に合わせる。
+ * 親 .programCell は overflow: clip (スクロールコンテナを作らない) なので、ここの
+ * sticky は外側 .scroll を基準に効く。
+ */
+.programContent {
+  position: sticky;
+  top: 6rem;
 }
 
 /* ジャンル (塗り = fill, 左バー = strong, 文字 = ink)。 */

--- a/client/components/organisms/Program/Table.tsx
+++ b/client/components/organisms/Program/Table.tsx
@@ -157,10 +157,12 @@ export default function ProgramTable(props: Props) {
                 }
               }}
             >
-              <ProgramItem
-                program={program}
-                state={schedule?.state}
-              />
+              <div className={styles.programContent}>
+                <ProgramItem
+                  program={program}
+                  state={schedule?.state}
+                />
+              </div>
             </div>
           );
         })}


### PR DESCRIPTION
## 概要

番組表を縦スクロールしたとき、長尺番組のセル内容 (時刻・タイトル等) が画面外へ流れて見えなくなっていた回帰を修正する。0.7.1 では sticky で追従していた。

## 原因

1. `.programCell` の `overflow: hidden`。これがセルをスクロールコンテナ化し、内側の sticky が外側のスクロール領域 (`.scroll`) 基準で効かなくなっていた。
2. 0.7.1 にあった sticky ラッパ (`.programContent { position: sticky; top: 6.4rem }`) が現状の実装に存在しなかった。番組内容がセル先頭に固定されたまま。

時刻列側 (`.timeNum { position: sticky; top: 6rem }`) は残っており追従していたため、番組セル側だけ追従しない状態だった。

## 対処

- `client/components/organisms/Program/Table.module.css`
  - `.programCell` の `overflow: hidden` → `overflow: clip`。`clip` はスクロールコンテナを生成せずクリップのみ行うため、子孫 sticky を外側スクロール基準で生かしつつ、短い番組の内容はみ出しを抑える既存挙動も維持する。
  - `.programContent { position: sticky; top: 6rem; }` を追加。`top` は sticky なヘッダ行 (`.serviceHeader` / `.timeNum`、高さ 6rem) の直下に合わせ、時刻ラベルと高さを揃える。
- `client/components/organisms/Program/Table.tsx`
  - `<ProgramItem>` を `<div className={styles.programContent}>` でラップ。sticky は番組表 (organism) のレイアウト都合のため、molecule (`ProgramItem`) ではなく organism 側に持たせる。

副作用として、録画ステータスバッジ (`.flagSlot`、絶対配置) の基準が sticky ラッパへ移り、バッジもタイトルと一緒に追従する。

## 確認

- `deno task check` (fmt / lint / 型) パス
- `deno task test:client` パス (315 tests)
- 実機のスクロール追従挙動は dev サーバ + mirakc データが必要なため未確認。CSS ロジックは上記のとおり。

🤖 Generated with [Claude Code](https://claude.com/claude-code)