### PR TITLE
feat: PC 表示時に番組表の列幅を広げる

### DIFF
--- a/client/components/organisms/Program/Table.module.css
+++ b/client/components/organisms/Program/Table.module.css
@@ -10,7 +10,18 @@
   position: relative;
   width: max-content;
   min-width: 100%;
-  /* grid-template-columns は Table.tsx が services 数に応じてインライン設定する。 */
+  /*
+   * サービス 1 列の幅。grid-template-columns 自体 (列数) は Table.tsx が services 数に
+   * 応じて組み立て、1 列の幅にこの変数を参照する。PC 既定を広めに取り、モバイル
+   * (<=640px) では従来幅へ戻す。
+   */
+  --service-col: 24rem;
+}
+
+@container style(--is-mobile: true) {
+  .grid {
+    --service-col: 17rem;
+  }
 }
 
 /* 左上の角 (時刻列ヘッダ)。 */

--- a/client/components/organisms/Program/Table.tsx
+++ b/client/components/organisms/Program/Table.tsx
@@ -52,8 +52,6 @@ const GENRE_CLASS: Record<GenreKey, string> = {
 
 /** 時刻列の幅 (rem)。 */
 const TIME_COL = 5.6;
-/** サービス 1 列の幅 (rem)。 */
-const SERVICE_COL = 17;
 
 export default function ProgramTable(props: Props) {
   const fromMs = props.displayFromMs;
@@ -86,7 +84,7 @@ export default function ProgramTable(props: Props) {
         style={{
           gridTemplateColumns: `${TIME_COL}rem repeat(${
             Math.max(services.length, 1)
-          }, ${SERVICE_COL}rem)`,
+          }, var(--service-col))`,
         }}
       >
         <div className={styles.cornerHead} />


### PR DESCRIPTION
## 概要

番組表のサービス 1 列の幅を、PC では従来の 17rem (170px) から 24rem (240px) に広げる。番組名 (タイトル) の視認性を上げるのが目的。モバイル (<=640px) は 17rem のまま据え置く。

## 対処

- `client/components/organisms/Program/Table.module.css`
  - `.grid` に CSS 変数 `--service-col: 24rem` (PC 既定) を定義。
  - `@container style(--is-mobile: true)` で `--service-col: 17rem` に戻す。PC/モバイルの分岐は他コンポーネントと同じ `--is-mobile` コンテナスタイルクエリ (640px 境界は palette.css が単一ソース) に乗せる。
- `client/components/organisms/Program/Table.tsx`
  - 列幅をインライン直値で設定していた定数 `SERVICE_COL` を撤去。`gridTemplateColumns` の 1 列幅を `var(--service-col)` 参照に変更。列数 (`repeat`) の組み立てだけ JS に残す。

## 確認

- `deno task check` (fmt / lint / 型) パス
- `deno task test:client` パス (323 tests)
- 実機の表示幅・モバイル分岐は dev サーバが必要なため未確認。値 (24rem) は CSS 変数 1 箇所で調整可能。

## 補足

sticky 追従の修正 (#60) とは別概念のため独立 PR。ベースは main で #60 を含まない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)