### PR TITLE
docs: PR 作成前の検証チェーンをルール化

### DIFF
--- a/.claude/rules/pr.md
+++ b/.claude/rules/pr.md
@@ -1,0 +1,11 @@
+# PR 作成前の検証
+
+- MUST: PR を作成する前に、次の検証チェーンを順に実行し、すべて成功させること。
+
+```sh
+deno task fix && deno task check && deno task lint && deno task test && deno task build
+```
+
+- 個別コマンドをその場で手組みせず、この並びをそのまま使う。
+- 失敗した場合は修正のうえ、チェーンを先頭から再実行する。
+- PR を伴わない push でも、push 前に同じチェーンを実行する。


### PR DESCRIPTION
PR 作成前に実行すべき検証チェーン (fix / check / lint / test / build) を `.claude/rules/pr.md` として明文化した。個別コマンドをその場で手組みせず、一連のチェーンをそのまま使う運用にする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)